### PR TITLE
Mass Cutscene Skips and Faster Start

### DIFF
--- a/code/Makefile
+++ b/code/Makefile
@@ -33,7 +33,7 @@ SOURCES		:=	source source/asm source/lib source/common source/game source/rnd
 DATA		:=	data
 INCLUDES	:=	include 
 INCLUDES    +=  assets
-#ROMFS		:=	romfs
+ROMFS		:=	romfs
 
 #---------------------------------------------------------------------------------
 # options for code generation

--- a/code/Makefile
+++ b/code/Makefile
@@ -33,7 +33,7 @@ SOURCES		:=	source source/asm source/lib source/common source/game source/rnd
 DATA		:=	data
 INCLUDES	:=	include 
 INCLUDES    +=  assets
-ROMFS		:=	romfs
+#ROMFS		:=	romfs
 
 #---------------------------------------------------------------------------------
 # options for code generation

--- a/code/include/game/common_data.h
+++ b/code/include/game/common_data.h
@@ -242,19 +242,19 @@ struct SaveData {
   InventoryData inventory;
   char field_24C;
   u8 gap249[938];
-  u8 IkanaCastleCameraPan_0x08;
+  u8 ikana_castle_camera_pan_0x08;
   u8 gap5FC[295]; //address name has been corrected to match savefile adddress
   int anonymous_44;
   u8 gap728[204];
-  u8 SkullKidBackstoryCutscene_0x10;
+  u8 skullkid_backstory_cutscene_0x10;
   u8 gap7F5[178]; //also been corrected
   char anonymous_45;
   u8 gap8A9[269];
-  u8 PiratesFortressExteriorCameraPan_0x04;
+  u8 pirates_fortress_exterior_camera_pan_0x04;
   u8 gap9B6[752]; //corrected
   int anonymous_46;
   u8 gapCAC[520];
-  u8 MeetingTheHappyMaskMan_0x01;
+  u8 meeting_happy_mask_salesman_0x01;
   u8 gapEB5[762]; //corrected
   int anonymous_47;
   int anonymous_48;
@@ -301,35 +301,35 @@ struct SaveData {
     u32 raw;
     
     BitField<0, 1, u32> unknown0;
-    BitField<1, 1, u32> TerminaField;
-    BitField<2, 1, u32> Graveyard;
-    BitField<3, 1, u32> RomaniRanch;
-    BitField<4, 2, u32> GormanTrack;
-    BitField<5, 1, u32> MountainVillage;
-    BitField<6, 1, u32> GoronCity;
-    BitField<7, 1, u32> Snowhead;
+    BitField<1, 1, u32> termina_field;
+    BitField<2, 1, u32> graveyard;
+    BitField<3, 1, u32> romani_ranch;
+    BitField<4, 2, u32> gorman_track;
+    BitField<5, 1, u32> mountain_village;
+    BitField<6, 1, u32> goron_city;
+    BitField<7, 1, u32> snowhead;
 
-    BitField<8, 1, u32> SouthernSwamp;
-    BitField<9, 1, u32> Woodfall;
-    BitField<10, 1, u32> DekuPalace;
-    BitField<11, 1, u32> GreatBayCoast;
-    BitField<12, 1, u32> PiratesFortress;
-    BitField<13, 1, u32> ZoraDomain;
-    BitField<14, 1, u32> WaterfallRapids;
-    BitField<15, 1, u32> IkanaCanyon;
+    BitField<8, 1, u32> southern_swamp;
+    BitField<9, 1, u32> woodfall;
+    BitField<10, 1, u32> deku_palace;
+    BitField<11, 1, u32> great_bay_coast;
+    BitField<12, 1, u32> pirates_fortress;
+    BitField<13, 1, u32> zora_domain;
+    BitField<14, 1, u32> waterfall_rapids;
+    BitField<15, 1, u32> ikana_canyon;
 
     BitField<16, 1, u32> unknown16;
-    BitField<17, 1, u32> StoneTower;
-    BitField<18, 1, u32> StoneTowerInverted;
-    BitField<19, 1, u32> EastClockTown;
-    BitField<20, 1, u32> WestClockTown;
-    BitField<21, 1, u32> NorthClockTown;
-    BitField<22, 1, u32> WoodfallTemple;
-    BitField<23, 1, u32> SnowheadTemple;
+    BitField<17, 1, u32> stone_tower;
+    BitField<18, 1, u32> stone_tower_inverted;
+    BitField<19, 1, u32> east_clock_town;
+    BitField<20, 1, u32> west_clock_town;
+    BitField<21, 1, u32> north_clock_town;
+    BitField<22, 1, u32> woodfall_temple;
+    BitField<23, 1, u32> snowhead_temple;
 
     BitField<24, 1, u32> unknown24;
-    BitField<25, 1, u32> StoneTowerTemple;
-    BitField<26, 1, u32> StoneTowerTempleInverted;
+    BitField<25, 1, u32> stone_tower_temple;
+    BitField<26, 1, u32> stone_tower_temple_inverted;
     BitField<27, 1, u32> unknown27;
     BitField<28, 1, u32> unknown28;
     BitField<29, 1, u32> unknown29;
@@ -428,11 +428,11 @@ struct SaveData {
   union CutSceneFlagsU8 {
     u8 raw;
 
-    BitField<0, 1, u8> OwlStatueCutScene;
+    BitField<0, 1, u8> owl_statue_cut_scene;
     BitField<1, 1, u8> unknown1;
     BitField<2, 1, u8> unknown2;
     BitField<3, 1, u8> unknown3;
-    BitField<4, 2, u8> DekuPalaceThroneRoomCutScene;
+    BitField<4, 2, u8> deku_palace_throne_room_cutscene;
     BitField<5, 1, u8> unknown5;
     BitField<6, 1, u8> unknown6;
     BitField<7, 1, u8> unknown7;
@@ -443,7 +443,7 @@ struct SaveData {
   char anonymous_155;
   char anonymous_156;
   char anonymous_157;
-  u8 RoadtoWoodfallCameraPan_0x08;
+  u8 road_to_woodfall_camera_pan_0x08;
   u8 ct_deku_flown_in_0x80_if_visited_once; // Possible event flags? Set to 80.
   char anonymous_160;
   u8 gap12DC[20];
@@ -452,8 +452,8 @@ struct SaveData {
   union UnknownFlags_U32 {
     u32 raw;
     
-    BitField<0, 1, u32> ClockTown;
-    BitField<1, 1, u32> TerminaField;
+    BitField<0, 1, u32> clock_town;
+    BitField<1, 1, u32> termina_field;
     BitField<2, 1, u32> unknown2;
     BitField<3, 1, u32> unknown3;
     BitField<4, 2, u32> unknown4;

--- a/code/include/game/common_data.h
+++ b/code/include/game/common_data.h
@@ -201,6 +201,7 @@ static_assert(sizeof(InventoryData) == 0xD4);
 static_assert(offsetof(InventoryData, inventory_count_register) == 0x78);
 
 struct SaveData {
+  //Todo rename gaps to account for byte differences
   MaskId mask;
   u8 has_completed_intro;
   char unused;
@@ -240,13 +241,21 @@ struct SaveData {
   EquipmentData equipment;
   InventoryData inventory;
   char field_24C;
-  u8 gap249[1235];
+  u8 gap249[938];
+  u8 IkanaCastleCameraPan_0x08;
+  u8 gap5FC[295]; //address name has been corrected
   int anonymous_44;
-  u8 gap728[384];
+  u8 gap728[204];
+  u8 SkullKidBackstoryCutscene_0x10;
+  u8 gap7F5[178]; //also been corrected
   char anonymous_45;
-  u8 gap8A9[1023];
+  u8 gap8A9[269];
+  u8 PiratesFortressExteriorCameraPan_0x04;
+  u8 gap9B6[752]; //corrected
   int anonymous_46;
-  u8 gapCAC[1284];
+  u8 gapCAC[520];
+  u8 MeetingTheHappyMaskMan_0x01;
+  u8 gapEB5[762]; //corrected
   int anonymous_47;
   int anonymous_48;
   int anonymous_49;
@@ -292,35 +301,35 @@ struct SaveData {
     u32 raw;
     
     BitField<0, 1, u32> unknown0;
-    BitField<1, 1, u32> unknown1;
-    BitField<2, 1, u32> unknown2;
-    BitField<3, 1, u32> unknown3;
-    BitField<4, 2, u32> unknown4;
-    BitField<5, 1, u32> unknown5;
-    BitField<6, 1, u32> unknown6;
-    BitField<7, 1, u32> unknown7;
+    BitField<1, 1, u32> TerminaField;
+    BitField<2, 1, u32> Graveyard;
+    BitField<3, 1, u32> RomaniRanch;
+    BitField<4, 2, u32> GormanTrack;
+    BitField<5, 1, u32> MountainVillage;
+    BitField<6, 1, u32> GoronCity;
+    BitField<7, 1, u32> Snowhead;
 
-    BitField<8, 1, u32> unknown8;
-    BitField<9, 1, u32> unknown9;
-    BitField<10, 1, u32> unknown10;
-    BitField<11, 1, u32> unknown11;
-    BitField<12, 1, u32> unknown12;
-    BitField<13, 1, u32> unknown13;
-    BitField<14, 1, u32> unknown14;
-    BitField<15, 1, u32> unknown15;
+    BitField<8, 1, u32> SouthernSwamp;
+    BitField<9, 1, u32> Woodfall;
+    BitField<10, 1, u32> DekuPalace;
+    BitField<11, 1, u32> GreatBayCoast;
+    BitField<12, 1, u32> PiratesFortress;
+    BitField<13, 1, u32> ZoraDomain;
+    BitField<14, 1, u32> WaterfallRapids;
+    BitField<15, 1, u32> IkanaCanyon;
 
     BitField<16, 1, u32> unknown16;
-    BitField<17, 1, u32> unknown17;
-    BitField<18, 1, u32> unknown18;
-    BitField<19, 1, u32> unknown19;
-    BitField<20, 1, u32> unknown20;
-    BitField<21, 1, u32> unknown21;
-    BitField<22, 1, u32> unknown22;
-    BitField<23, 1, u32> unknown23;
+    BitField<17, 1, u32> StoneTower;
+    BitField<18, 1, u32> StoneTowerInverted;
+    BitField<19, 1, u32> EastClockTown;
+    BitField<20, 1, u32> WestClockTown;
+    BitField<21, 1, u32> NorthClockTown;
+    BitField<22, 1, u32> WoodfallTemple;
+    BitField<23, 1, u32> SnowheadTemple;
 
     BitField<24, 1, u32> unknown24;
-    BitField<25, 1, u32> unknown25;
-    BitField<26, 1, u32> unknown26;
+    BitField<25, 1, u32> StoneTowerTemple;
+    BitField<26, 1, u32> StoneTowerTempleInverted;
     BitField<27, 1, u32> unknown27;
     BitField<28, 1, u32> unknown28;
     BitField<29, 1, u32> unknown29;
@@ -416,19 +425,70 @@ struct SaveData {
   char anonymous_149;
   char anonymous_150;
   char anonymous_151;
-  char anonymous_152_saved_once_0x10_sot_once_0x40;
+  union CutSceneFlagsU8 {
+    u8 raw;
+
+    BitField<0, 1, u8> OwlStatueCutScene;
+    BitField<1, 1, u8> unknown1;
+    BitField<2, 1, u8> unknown2;
+    BitField<3, 1, u8> unknown3;
+    BitField<4, 2, u8> DekuPalaceThroneRoomCutScene;
+    BitField<5, 1, u8> unknown5;
+    BitField<6, 1, u8> unknown6;
+    BitField<7, 1, u8> unknown7;
+  };
+  CutSceneFlagsU8 CutSceneFlagBundle2; //char anonymous_152_saved_once_0x10_sot_once_0x40;
   char anonymous_153;
   char anonymous_154;
   char anonymous_155;
   char anonymous_156;
   char anonymous_157;
-  char anonymous_158;
+  u8 RoadtoWoodfallCameraPan_0x08;
   u8 ct_deku_flown_in_0x80_if_visited_once; // Possible event flags? Set to 80.
   char anonymous_160;
   u8 gap12DC[20];
-  //More Event flags
-  //int anonymous_161;
-  CutSceneFlagsU32 CutSceneFlagBundle2;
+  //Possibly flags for locations visted or game progression counter
+  //Does not affect cutscenes
+  union UnknownFlags_U32 {
+    u32 raw;
+    
+    BitField<0, 1, u32> ClockTown;
+    BitField<1, 1, u32> TerminaField;
+    BitField<2, 1, u32> unknown2;
+    BitField<3, 1, u32> unknown3;
+    BitField<4, 2, u32> unknown4;
+    BitField<5, 1, u32> unknown5;
+    BitField<6, 1, u32> unknown6;
+    BitField<7, 1, u32> unknown7;
+
+    BitField<8, 1, u32> unknown8;
+    BitField<9, 1, u32> unknown9;
+    BitField<10, 1, u32> unknown10;
+    BitField<11, 1, u32> unknown11;
+    BitField<12, 1, u32> unknown12;
+    BitField<13, 1, u32> unknown13;
+    BitField<14, 1, u32> unknown14;
+    BitField<15, 1, u32> unknown15;
+
+    BitField<16, 1, u32> unknown16;
+    BitField<17, 1, u32> unknown17;
+    BitField<18, 1, u32> unknown18;
+    BitField<19, 1, u32> unknown19;
+    BitField<20, 1, u32> unknown20;
+    BitField<21, 1, u32> unknown21;
+    BitField<22, 1, u32> unknown22;
+    BitField<23, 1, u32> unknown23;
+
+    BitField<24, 1, u32> unknown24;
+    BitField<25, 1, u32> unknown25;
+    BitField<26, 1, u32> unknown26;
+    BitField<27, 1, u32> unknown27;
+    BitField<28, 1, u32> unknown28;
+    BitField<29, 1, u32> unknown29;
+    BitField<30, 1, u32> unknown30;
+    BitField<31, 1, u32> unknown31;
+  };
+  UnknownFlags_U32 UnknownFlagBundle; //int anonymous_161;
   int anonymous_162;
   u8 gap12F8;
   char anonymous_163;

--- a/code/include/game/common_data.h
+++ b/code/include/game/common_data.h
@@ -336,7 +336,7 @@ struct SaveData {
     BitField<30, 1, u32> unknown30;
     BitField<31, 1, u32> unknown31;
   };
-  CutSceneFlagsU32 CutSceneFlagBundle1;
+  CutSceneFlagsU32 cut_scene_flag_bundle1;
   u8 gap1254[3];
   char anonymous_71;
   char anonymous_72;
@@ -437,7 +437,7 @@ struct SaveData {
     BitField<6, 1, u8> unknown6;
     BitField<7, 1, u8> unknown7;
   };
-  CutSceneFlagsU8 CutSceneFlagBundle2; //char anonymous_152_saved_once_0x10_sot_once_0x40;
+  CutSceneFlagsU8 cut_scene_flag_bundle2; //char anonymous_152_saved_once_0x10_sot_once_0x40;
   char anonymous_153;
   char anonymous_154;
   char anonymous_155;
@@ -488,7 +488,7 @@ struct SaveData {
     BitField<30, 1, u32> unknown30;
     BitField<31, 1, u32> unknown31;
   };
-  UnknownFlags_U32 UnknownFlagBundle; //int anonymous_161;
+  UnknownFlags_U32 unknown_flag_bundle; //int anonymous_161;
   int anonymous_162;
   u8 gap12F8;
   char anonymous_163;

--- a/code/include/game/common_data.h
+++ b/code/include/game/common_data.h
@@ -201,7 +201,7 @@ static_assert(sizeof(InventoryData) == 0xD4);
 static_assert(offsetof(InventoryData, inventory_count_register) == 0x78);
 
 struct SaveData {
-  //Todo rename gaps to account for byte differences
+  //Todo: rename gaps to match savefile location
   MaskId mask;
   u8 has_completed_intro;
   char unused;
@@ -243,7 +243,7 @@ struct SaveData {
   char field_24C;
   u8 gap249[938];
   u8 IkanaCastleCameraPan_0x08;
-  u8 gap5FC[295]; //address name has been corrected
+  u8 gap5FC[295]; //address name has been corrected to match savefile adddress
   int anonymous_44;
   u8 gap728[204];
   u8 SkullKidBackstoryCutscene_0x10;
@@ -374,7 +374,7 @@ struct SaveData {
   char anonymous_103;
   char anonymous_104;
   u8 gap127A[8];
-  char anonymous_105; //0x1282
+  char anonymous_105;
   char anonymous_106;
   char anonymous_107;
   char anonymous_108;

--- a/code/include/game/common_data.h
+++ b/code/include/game/common_data.h
@@ -281,10 +281,54 @@ struct SaveData {
   int anonymous_67;
   int anonymous_68;
   u8 gap1244[4];
+  //Cutscene flag bundle
+  /*
   u8 event_reg_maybe;
   char anonymous_69;
   char anonymous_70;
-  u8 gap1253[4];
+  u8 gap1253;
+  */
+  union CutSceneFlagsU32 {
+    u32 raw;
+    
+    BitField<0, 1, u32> unknown0;
+    BitField<1, 1, u32> unknown1;
+    BitField<2, 1, u32> unknown2;
+    BitField<3, 1, u32> unknown3;
+    BitField<4, 2, u32> unknown4;
+    BitField<5, 1, u32> unknown5;
+    BitField<6, 1, u32> unknown6;
+    BitField<7, 1, u32> unknown7;
+
+    BitField<8, 1, u32> unknown8;
+    BitField<9, 1, u32> unknown9;
+    BitField<10, 1, u32> unknown10;
+    BitField<11, 1, u32> unknown11;
+    BitField<12, 1, u32> unknown12;
+    BitField<13, 1, u32> unknown13;
+    BitField<14, 1, u32> unknown14;
+    BitField<15, 1, u32> unknown15;
+
+    BitField<16, 1, u32> unknown16;
+    BitField<17, 1, u32> unknown17;
+    BitField<18, 1, u32> unknown18;
+    BitField<19, 1, u32> unknown19;
+    BitField<20, 1, u32> unknown20;
+    BitField<21, 1, u32> unknown21;
+    BitField<22, 1, u32> unknown22;
+    BitField<23, 1, u32> unknown23;
+
+    BitField<24, 1, u32> unknown24;
+    BitField<25, 1, u32> unknown25;
+    BitField<26, 1, u32> unknown26;
+    BitField<27, 1, u32> unknown27;
+    BitField<28, 1, u32> unknown28;
+    BitField<29, 1, u32> unknown29;
+    BitField<30, 1, u32> unknown30;
+    BitField<31, 1, u32> unknown31;
+  };
+  CutSceneFlagsU32 CutSceneFlagBundle1;
+  u8 gap1254[3];
   char anonymous_71;
   char anonymous_72;
   char anonymous_73;
@@ -321,7 +365,7 @@ struct SaveData {
   char anonymous_103;
   char anonymous_104;
   u8 gap127A[8];
-  char anonymous_105;
+  char anonymous_105; //0x1282
   char anonymous_106;
   char anonymous_107;
   char anonymous_108;
@@ -345,7 +389,7 @@ struct SaveData {
   char anonymous_125;
   char anonymous_126;
   char anonymous_127;
-  char anonymous_128;
+  char anonymous_128;  //Possibly more Cutscene flags
   char anonymous_129;
   char anonymous_130;
   char anonymous_131;
@@ -382,7 +426,9 @@ struct SaveData {
   u8 ct_deku_flown_in_0x80_if_visited_once; // Possible event flags? Set to 80.
   char anonymous_160;
   u8 gap12DC[20];
-  int anonymous_161;
+  //More Event flags
+  //int anonymous_161;
+  CutSceneFlagsU32 CutSceneFlagBundle2;
   int anonymous_162;
   u8 gap12F8;
   char anonymous_163;

--- a/code/include/rnd/item_override.h
+++ b/code/include/rnd/item_override.h
@@ -198,6 +198,7 @@ namespace rnd {
     /* 0xB8 */ GI_MAP_OF_GREAT_BAY,
     /* 0xB9 */ GI_MAP_OF_STONE_TOWER,
     /* 0xBA */ GI_FISHING_HOLE_PASS,
+    /* 0xBB */ //GAME CRASH no more item IDs after?
 };
 
   enum class DrawGraphicItemID : s32 {

--- a/code/include/rnd/item_override.h
+++ b/code/include/rnd/item_override.h
@@ -198,7 +198,6 @@ namespace rnd {
     /* 0xB8 */ GI_MAP_OF_GREAT_BAY,
     /* 0xB9 */ GI_MAP_OF_STONE_TOWER,
     /* 0xBA */ GI_FISHING_HOLE_PASS,
-    /* 0xBB */ //GAME CRASH no more item IDs after?
 };
 
   enum class DrawGraphicItemID : s32 {

--- a/code/include/rnd/savefile.h
+++ b/code/include/rnd/savefile.h
@@ -5,6 +5,7 @@
 #include "z3d/z3DVec.h"
 
 namespace rnd {
+  void MassCutSceneSkip();
   u8 SaveFile_GetMedallionCount(void);
   u8 SaveFile_GetStoneCount(void);
   u8 SaveFile_GetDungeonCount(void);

--- a/code/include/rnd/savefile.h
+++ b/code/include/rnd/savefile.h
@@ -5,7 +5,7 @@
 #include "z3d/z3DVec.h"
 
 namespace rnd {
-  void MassCutSceneSkip();
+  void SaveFile_SkipMinorCutscenes();
   u8 SaveFile_GetMedallionCount(void);
   u8 SaveFile_GetStoneCount(void);
   u8 SaveFile_GetDungeonCount(void);

--- a/code/include/rnd/savefile.h
+++ b/code/include/rnd/savefile.h
@@ -6,6 +6,7 @@
 
 namespace rnd {
   void SaveFile_SkipMinorCutscenes();
+  void SaveFile_SetStartingOwlStatues();
   u8 SaveFile_GetMedallionCount(void);
   u8 SaveFile_GetStoneCount(void);
   u8 SaveFile_GetDungeonCount(void);

--- a/code/include/rnd/settings.h
+++ b/code/include/rnd/settings.h
@@ -325,7 +325,7 @@ namespace rnd {
     // ARM Patch Checks
     u8 enableFastZoraSwim = 1;
     u8 enableOcarinaDiving = 1;
-    u8 enableFastElegyStatues = 0;
+    u8 enableFastElegyStatues = 1;
   } SettingsContext;
 
   extern "C" SettingsContext gSettingsContext;

--- a/code/include/rnd/settings.h
+++ b/code/include/rnd/settings.h
@@ -326,7 +326,7 @@ namespace rnd {
     // ARM Patch Checks
     u8 enableFastZoraSwim = 1;
     u8 enableOcarinaDiving = 1;
-    u8 enableFastElegyStatues = 1;
+    u8 enableFastElegyStatues = 0;
   } SettingsContext;
 
   extern "C" SettingsContext gSettingsContext;

--- a/code/include/rnd/settings.h
+++ b/code/include/rnd/settings.h
@@ -325,7 +325,7 @@ namespace rnd {
     // ARM Patch Checks
     u8 enableFastZoraSwim = 1;
     u8 enableOcarinaDiving = 1;
-    u8 enableFastElegyStatues = 1;
+    u8 enableFastElegyStatues = 0;
   } SettingsContext;
 
   extern "C" SettingsContext gSettingsContext;

--- a/code/include/rnd/settings.h
+++ b/code/include/rnd/settings.h
@@ -321,11 +321,12 @@ namespace rnd {
     u32 startingDungeonReward;
     u32 startingEquipment;
     u32 startingUpgrades;
+    //u16 startingOwlStatues;
 
     // ARM Patch Checks
     u8 enableFastZoraSwim = 1;
     u8 enableOcarinaDiving = 1;
-    u8 enableFastElegyStatues = 0;
+    u8 enableFastElegyStatues = 1;
   } SettingsContext;
 
   extern "C" SettingsContext gSettingsContext;

--- a/code/source/rnd/item_override.cpp
+++ b/code/source/rnd/item_override.cpp
@@ -34,12 +34,10 @@ namespace rnd {
     rItemOverrides[0].key.type = ItemOverride_Type::OVR_COLLECTABLE;
     rItemOverrides[0].value.getItemId = 0x37;
     rItemOverrides[0].value.looksLikeItemId = 0x37;
-    rItemOverrides_Count++;
     rItemOverrides[1].key.scene = 0x6C;
     rItemOverrides[1].key.type = ItemOverride_Type::OVR_CHEST;
     rItemOverrides[1].value.getItemId = 0x37;
     rItemOverrides[1].value.looksLikeItemId = 0x37;
-    rItemOverrides_Count++;
     #endif
     while (rItemOverrides[rItemOverrides_Count].key.all != 0) {
       rItemOverrides_Count++;
@@ -142,10 +140,10 @@ namespace rnd {
     
     ItemRow *itemRow = ItemTable_GetItemRow(resolvedGetItemId);
     u8 looksLikeItemId = override.value.looksLikeItemId;
-    /*
+    
     if (override.value.getItemId == 0x12) { // Ice trap
       looksLikeItemId = 0;
-    }*/
+    }
 
     rActiveItemOverride = override;
     rActiveItemRow = itemRow;

--- a/code/source/rnd/item_override.cpp
+++ b/code/source/rnd/item_override.cpp
@@ -34,10 +34,12 @@ namespace rnd {
     rItemOverrides[0].key.type = ItemOverride_Type::OVR_COLLECTABLE;
     rItemOverrides[0].value.getItemId = 0x37;
     rItemOverrides[0].value.looksLikeItemId = 0x37;
+    rItemOverrides_Count++;
     rItemOverrides[1].key.scene = 0x6C;
     rItemOverrides[1].key.type = ItemOverride_Type::OVR_CHEST;
     rItemOverrides[1].value.getItemId = 0x37;
     rItemOverrides[1].value.looksLikeItemId = 0x37;
+    rItemOverrides_Count++;
     #endif
     while (rItemOverrides[rItemOverrides_Count].key.all != 0) {
       rItemOverrides_Count++;
@@ -140,9 +142,10 @@ namespace rnd {
     
     ItemRow *itemRow = ItemTable_GetItemRow(resolvedGetItemId);
     u8 looksLikeItemId = override.value.looksLikeItemId;
+    /*
     if (override.value.getItemId == 0x12) { // Ice trap
       looksLikeItemId = 0;
-    }
+    }*/
 
     rActiveItemOverride = override;
     rActiveItemRow = itemRow;
@@ -150,6 +153,9 @@ namespace rnd {
     rActiveItemTextId = itemRow->textId;
     rActiveItemObjectId = itemRow->objectId;
     rActiveItemGraphicId = looksLikeItemId ? ItemTable_GetItemRow(looksLikeItemId)->graphicId : itemRow->graphicId;
+    #ifdef ENABLE_DEBUG
+      //rActiveItemGraphicId = 0x87;
+    #endif
     rActiveItemFastChest = (u32)itemRow->chestType & 0x01;
   }
 
@@ -415,6 +421,7 @@ namespace rnd {
     ItemOverride_Activate(override);
     s16 baseItemId = rActiveItemRow->baseItemId;
     
+    //fromActor->params = (fromActor->params & 0xF01F) | (baseItemId << 5);
     
     //s8 baseItemId = rActiveItemRow->textId;
     if (override.value.getItemId == 0x12) {

--- a/code/source/rnd/item_override.cpp
+++ b/code/source/rnd/item_override.cpp
@@ -421,8 +421,6 @@ namespace rnd {
     ItemOverride_Activate(override);
     s16 baseItemId = rActiveItemRow->baseItemId;
     
-    //fromActor->params = (fromActor->params & 0xF01F) | (baseItemId << 5);
-    
     //s8 baseItemId = rActiveItemRow->textId;
     if (override.value.getItemId == 0x12) {
       rActiveItemRow->effectArg1 = override.key.all >> 16;

--- a/code/source/rnd/savefile.cpp
+++ b/code/source/rnd/savefile.cpp
@@ -87,14 +87,13 @@ namespace rnd {
     saveData.inventory.collect_register.eponas_song = 1;
 
     //extra/temp testing items
-    saveData.inventory.collect_register.sarias_song = 1;
+    //saveData.inventory.collect_register.sarias_song = 1;
 #endif
     //TODO: Decomp event flags. Most likely in the large anonymous structs in the SaveData.
     u8 isNewFile = saveData.has_completed_intro;
     if (isNewFile == 0) {
       saveData.has_completed_intro = 0x2B;
       saveData.inventory.items[0] = game::ItemId::Ocarina;
-      saveData.player.razor_sword_hp = 0xFFFF;
 
       //TODO Time Savers:
       //Bomber's minigame skip ie. open hideout
@@ -142,7 +141,7 @@ namespace rnd {
     
     //Addresses 0x1250 to 0x1253
     //saveData.event_reg_maybe = 0xFE; as 1111 1110 in savefile
-    saveData.CutSceneFlagBundle1.unknown0 = 0;
+    //saveData.CutSceneFlagBundle1.unknown0 = 0;
     saveData.CutSceneFlagBundle1.TerminaField = 1;
     saveData.CutSceneFlagBundle1.Graveyard = 1;
     saveData.CutSceneFlagBundle1.RomaniRanch = 1;
@@ -162,7 +161,7 @@ namespace rnd {
     saveData.CutSceneFlagBundle1.IkanaCanyon = 1;
 
     //saveData.anonymous_70 = 0xFE; as 1111 1110 in savefile
-    saveData.CutSceneFlagBundle1.unknown16 = 0;
+    //saveData.CutSceneFlagBundle1.unknown16 = 0;
     saveData.CutSceneFlagBundle1.StoneTower = 1;
     saveData.CutSceneFlagBundle1.StoneTowerInverted = 1;
     saveData.CutSceneFlagBundle1.EastClockTown = 1;
@@ -172,27 +171,27 @@ namespace rnd {
     saveData.CutSceneFlagBundle1.SnowheadTemple = 1;
 
     //saveData.gap1253 = 0x06; written as 0000 0110 in savefile
-    saveData.CutSceneFlagBundle1.unknown24 = 0;
+    //saveData.CutSceneFlagBundle1.unknown24 = 0;
     saveData.CutSceneFlagBundle1.StoneTowerTemple = 1; 
     saveData.CutSceneFlagBundle1.StoneTowerTempleInverted = 1;  
-    saveData.CutSceneFlagBundle1.unknown27 = 0;
-    saveData.CutSceneFlagBundle1.unknown28 = 0;
-    saveData.CutSceneFlagBundle1.unknown29 = 0;
-    saveData.CutSceneFlagBundle1.unknown30 = 0;
-    saveData.CutSceneFlagBundle1.unknown31 = 0;
+    //saveData.CutSceneFlagBundle1.unknown27 = 0;
+    //saveData.CutSceneFlagBundle1.unknown28 = 0;
+    //saveData.CutSceneFlagBundle1.unknown29 = 0;
+    //saveData.CutSceneFlagBundle1.unknown30 = 0;
+    //saveData.CutSceneFlagBundle1.unknown31 = 0;
     
     //GreatbayTemple not in bundle above, does not seem to have a camera pan scene
 
     //ClockTown Owl statue: 0x12D3 = 0x10
     //saveData.anonymous_152_saved_once_0x10_sot_once_0x40 = 0x11;// 0x01 is deku palace
     saveData.CutSceneFlagBundle2.OwlStatueCutScene = 1;
-    saveData.CutSceneFlagBundle2.unknown1 = 0;
-    saveData.CutSceneFlagBundle2.unknown2 = 0;
-    saveData.CutSceneFlagBundle2.unknown3 = 0;
+    //saveData.CutSceneFlagBundle2.unknown1 = 0;
+    //saveData.CutSceneFlagBundle2.unknown2 = 0;
+    //saveData.CutSceneFlagBundle2.unknown3 = 0;
     saveData.CutSceneFlagBundle2.DekuPalaceThroneRoomCutScene = 1;
-    saveData.CutSceneFlagBundle2.unknown5 = 0;
-    saveData.CutSceneFlagBundle2.unknown6 = 0;
-    saveData.CutSceneFlagBundle2.unknown7 = 0;
+    //saveData.CutSceneFlagBundle2.unknown5 = 0;
+    //saveData.CutSceneFlagBundle2.unknown6 = 0;
+    //saveData.CutSceneFlagBundle2.unknown7 = 0;
 
     //Meeting the Happy Mask Salesman: 
     //0x0EB4 = 0x01

--- a/code/source/rnd/savefile.cpp
+++ b/code/source/rnd/savefile.cpp
@@ -96,66 +96,20 @@ namespace rnd {
       saveData.inventory.items[0] = game::ItemId::Ocarina;
       saveData.player.razor_sword_hp = 0xFFFF;
 
-
       //TODO Time Savers:
-      //Bomber's minigame skip
+      //Bomber's minigame skip ie. open hideout
       //Allow first time transformation to be skipable
-      //Find flag for navi diologue at woodfall temple entrance platform
-      //Find flag for navi diologue at snowhead entrance
-      //Faster dungeon cutscene for swamp, mountain and zora
+      //Find flag for tatl dialogue at woodfall temple entrance platform
+      //Find flag for tatl dialogue at snowhead entrance
+      //Faster/skip dungeon unlock cutscene for swamp, mountain and zora
       //Fast songs works but needs to be applied to first time played too
       //skip Ikana king diolouge intro
       //skip pushing zora to shore
       //skip pirate leader diologue
 
-      //Mass cutscene skip attemp
+      //Skips cutscenes with no item checks attached
+      //Also does not skip location access cutscenes like woodfall temple rise
       MassCutSceneSkip();
-      
-      //Cutscene skip comment explanation:
-      //name_of_cutscene: offset_address_in_save_file = value_in_hex
-      //offest address in save file has a quivalent address in save struct
-
-      //deku palace interior: 
-      //0x0A28 = 0x01 and 0x0A2C = 0x10
-      //0x07C8 = 0x01 and 0x07CC = 0x10 
-      saveData.gap8A9[383] = 0x01;
-      saveData.gap8A9[387] = 0x10;
-      saveData.gap728[160] = 0x01;
-      saveData.gap728[164] = 0x10;
-
-      //Road to Woodfall: 0x12D9 = 0x08, read as 1000 0000 in game
-      saveData.anonymous_158 = 0x08;
-
-      //Ikana Castle from canyon: 0x04C8 = 0x01 and 0x04CC = 0x08
-      //0x05F4 = 0x08, 0x05FB = 0x80
-      //0x0604 = 0x01, 0x0608 = 0x04
-      saveData.gap249[955] = 0x01;
-      saveData.gap249[959] = 0x04;
-      //0x1048 = 0x01, 0x104C = 0x10
-      saveData.gapCAC[924] = 0x01;
-      saveData.gapCAC[928] = 0x10;
-      //0x128B = 0x05, 0x012DC = 0x88
-      saveData.skip_tatl_talking_0x04 = 0x05;
-      saveData.ct_deku_flown_in_0x80_if_visited_once = 0x88;
-
-      //Meeting the Happy Mask Salesman: 0x0EB4 = 0x01, 0x0EC8 = 0x01
-      //0x0ECC = 0x10,
-
-      saveData.gapCAC[520] = 0x01;
-      saveData.gapCAC[540] = 0x01;
-      saveData.gapCAC[544] = 0x10;
-
-      //ClockTown Owl statue: 0x12AC = 0x80, 0x12D3 = 0x10 
-      saveData.anonymous_140 = 0x80;
-      saveData.anonymous_152_saved_once_0x10_sot_once_0x40 = 0x10;
-
-      //SkullKid backstory cutscene: 0x07F4 = 0x10 and 0x12F3 = 10
-      //0x0F08 = 0x04 and 0x0F0C = 0x10
-      saveData.gap728[204] = 0x10;
-      saveData.anonymous_162 = 0x10;
-      saveData.gapCAC[604] = 0x04;
-      saveData.gapCAC[608] = 0x10;
-
 
       saveData.ct_guard_allows_through_if_0x30 = 0x30;
 
@@ -171,20 +125,12 @@ namespace rnd {
       saveData.inventory.collect_register.song_of_soaring = 1;
 
       saveData.has_tatl = true;
-      //saveData.ct_deku_flown_in_0x80_if_visited_once = 0x80;
+      saveData.ct_deku_flown_in_0x80_if_visited_once = 0x80;
       saveData.ct_deku_in_flower_0x04_if_present = 0x04;
-      //saveData.skip_tatl_talking_0x04 = 0x04;
+      saveData.skip_tatl_talking_0x04 = 0x04;
       //saveData.player.tatl_timer_maybe = 0x1000;
       //saveData.ct_deku_removed_if_c0 = 0xC0;
       saveData.player_form = game::act::Player::Form::Human;
-
-      /*
-      #ifdef ENABLE_DEBUG
-      saveData.player_form = game::act::Player::Form::Human;
-      #else
-      saveData.player_form = game::act::Player::Form::Deku;
-      #endif
-      */
       //game::GiveItem(game::ItemId::BombersNotebook);
     }
     
@@ -192,99 +138,83 @@ namespace rnd {
 
   void MassCutSceneSkip() {
     game::SaveData &saveData = game::GetCommonData().save;
-    //found a potential bitfeild for a large number of camera pan cutscenes
-    //Have yet to decipher which bits correspond to what cutscene
-
-    //failed at pirate fortress exterior
-    //failed at deku palace interior
-    //failed at ikana castle
-
-    /*
-    //0x1250 to 0x1253
-    saveData.event_reg_maybe = 0xFE; written as 0111 1111 in bitfield/savefile
-    saveData.anonymous_69 = 0xFF;
-    saveData.anonymous_70 = 0xFE;
-    saveData.gap1253 = 0x06; written as 0110 0000 in bitfield/savefile
-    */
-
+    //addresses listed in comments is where it is in the savefile
+    
+    //Addresses 0x1250 to 0x1253
+    //saveData.event_reg_maybe = 0xFE; as 1111 1110 in savefile
     saveData.CutSceneFlagBundle1.unknown0 = 0;
-    saveData.CutSceneFlagBundle1.unknown1 = 1;
-    saveData.CutSceneFlagBundle1.unknown2 = 1;
-    saveData.CutSceneFlagBundle1.unknown3 = 1;
-    saveData.CutSceneFlagBundle1.unknown4 = 1;
-    saveData.CutSceneFlagBundle1.unknown5 = 1;
-    saveData.CutSceneFlagBundle1.unknown6 = 1;
-    saveData.CutSceneFlagBundle1.unknown7 = 1;
+    saveData.CutSceneFlagBundle1.TerminaField = 1;
+    saveData.CutSceneFlagBundle1.Graveyard = 1;
+    saveData.CutSceneFlagBundle1.RomaniRanch = 1;
+    saveData.CutSceneFlagBundle1.GormanTrack = 1;
+    saveData.CutSceneFlagBundle1.MountainVillage = 1;
+    saveData.CutSceneFlagBundle1.GoronCity = 1;
+    saveData.CutSceneFlagBundle1.Snowhead = 1;
 
-    saveData.CutSceneFlagBundle1.unknown8 = 1;
-    saveData.CutSceneFlagBundle1.unknown9 = 1;
-    saveData.CutSceneFlagBundle1.unknown10 = 1;
-    saveData.CutSceneFlagBundle1.unknown11 = 1;
-    saveData.CutSceneFlagBundle1.unknown12 = 1;
-    saveData.CutSceneFlagBundle1.unknown13 = 1;
-    saveData.CutSceneFlagBundle1.unknown14 = 1;
-    saveData.CutSceneFlagBundle1.unknown15 = 1;
+    //saveData.anonymous_69 = 0xFF;
+    saveData.CutSceneFlagBundle1.SouthernSwamp = 1;
+    saveData.CutSceneFlagBundle1.Woodfall = 1;
+    saveData.CutSceneFlagBundle1.DekuPalace = 1;
+    saveData.CutSceneFlagBundle1.GreatBayCoast = 1;
+    saveData.CutSceneFlagBundle1.PiratesFortress = 1;
+    saveData.CutSceneFlagBundle1.ZoraDomain = 1;
+    saveData.CutSceneFlagBundle1.WaterfallRapids = 1;
+    saveData.CutSceneFlagBundle1.IkanaCanyon = 1;
 
+    //saveData.anonymous_70 = 0xFE; as 1111 1110 in savefile
     saveData.CutSceneFlagBundle1.unknown16 = 0;
-    saveData.CutSceneFlagBundle1.unknown17 = 1;
-    saveData.CutSceneFlagBundle1.unknown18 = 1;
-    saveData.CutSceneFlagBundle1.unknown19 = 1;
-    saveData.CutSceneFlagBundle1.unknown20 = 1;
-    saveData.CutSceneFlagBundle1.unknown21 = 1;
-    saveData.CutSceneFlagBundle1.unknown22 = 1;
-    saveData.CutSceneFlagBundle1.unknown23 = 1;
+    saveData.CutSceneFlagBundle1.StoneTower = 1;
+    saveData.CutSceneFlagBundle1.StoneTowerInverted = 1;
+    saveData.CutSceneFlagBundle1.EastClockTown = 1;
+    saveData.CutSceneFlagBundle1.WestClockTown = 1;
+    saveData.CutSceneFlagBundle1.NorthClockTown = 1;
+    saveData.CutSceneFlagBundle1.WoodfallTemple = 1;
+    saveData.CutSceneFlagBundle1.SnowheadTemple = 1;
 
+    //saveData.gap1253 = 0x06; written as 0000 0110 in savefile
     saveData.CutSceneFlagBundle1.unknown24 = 0;
-    saveData.CutSceneFlagBundle1.unknown25 = 1;
-    saveData.CutSceneFlagBundle1.unknown26 = 1;
+    saveData.CutSceneFlagBundle1.StoneTowerTemple = 1; 
+    saveData.CutSceneFlagBundle1.StoneTowerTempleInverted = 1;  
     saveData.CutSceneFlagBundle1.unknown27 = 0;
     saveData.CutSceneFlagBundle1.unknown28 = 0;
     saveData.CutSceneFlagBundle1.unknown29 = 0;
     saveData.CutSceneFlagBundle1.unknown30 = 0;
     saveData.CutSceneFlagBundle1.unknown31 = 0;
     
-    //0x12F0 to 0x12F4
-    //saveData.anonymous_161 = 0x7F EF EF 7F;
-    // written as 1111 1110   1111 0111   1111 0111   1111 1110 in bitfield/savefile
+    //GreatbayTemple not in bundle above, does not seem to have a camera pan scene
 
-    saveData.CutSceneFlagBundle2.unknown0 = 1;
-    saveData.CutSceneFlagBundle2.unknown1 = 1;
-    saveData.CutSceneFlagBundle2.unknown2 = 1;
-    saveData.CutSceneFlagBundle2.unknown3 = 1;
-    saveData.CutSceneFlagBundle2.unknown4 = 1;
-    saveData.CutSceneFlagBundle2.unknown5 = 1;
-    saveData.CutSceneFlagBundle2.unknown6 = 1;
+    //ClockTown Owl statue: 0x12D3 = 0x10
+    //saveData.anonymous_152_saved_once_0x10_sot_once_0x40 = 0x11;// 0x01 is deku palace
+    saveData.CutSceneFlagBundle2.OwlStatueCutScene = 1;
+    saveData.CutSceneFlagBundle2.unknown1 = 0;
+    saveData.CutSceneFlagBundle2.unknown2 = 0;
+    saveData.CutSceneFlagBundle2.unknown3 = 0;
+    saveData.CutSceneFlagBundle2.DekuPalaceThroneRoomCutScene = 1;
+    saveData.CutSceneFlagBundle2.unknown5 = 0;
+    saveData.CutSceneFlagBundle2.unknown6 = 0;
     saveData.CutSceneFlagBundle2.unknown7 = 0;
 
-    saveData.CutSceneFlagBundle2.unknown8 = 1;
-    saveData.CutSceneFlagBundle2.unknown9 = 1;
-    saveData.CutSceneFlagBundle2.unknown10 = 1;
-    saveData.CutSceneFlagBundle2.unknown11 = 1;
-    saveData.CutSceneFlagBundle2.unknown12 = 0;
-    saveData.CutSceneFlagBundle2.unknown13 = 1;
-    saveData.CutSceneFlagBundle2.unknown14 = 1;
-    saveData.CutSceneFlagBundle2.unknown15 = 1;
+    //Meeting the Happy Mask Salesman: 
+    //0x0EB4 = 0x01
+    saveData.MeetingTheHappyMaskMan_0x01 = 0x01;
 
-    saveData.CutSceneFlagBundle2.unknown16 = 1;
-    saveData.CutSceneFlagBundle2.unknown17 = 1;
-    saveData.CutSceneFlagBundle2.unknown18 = 1;
-    saveData.CutSceneFlagBundle2.unknown19 = 1;
-    saveData.CutSceneFlagBundle2.unknown20 = 0;
-    saveData.CutSceneFlagBundle2.unknown21 = 1;
-    saveData.CutSceneFlagBundle2.unknown22 = 1;
-    saveData.CutSceneFlagBundle2.unknown23 = 1;
+    //SkullKid backstory cutscene:
+    //0x07F4 = 0x10 
+    saveData.SkullKidBackstoryCutscene_0x10 = 0x10;
 
-    saveData.CutSceneFlagBundle2.unknown24 = 1;
-    saveData.CutSceneFlagBundle2.unknown25 = 1;
-    saveData.CutSceneFlagBundle2.unknown26 = 1;
-    saveData.CutSceneFlagBundle2.unknown27 = 1;
-    saveData.CutSceneFlagBundle2.unknown28 = 1;
-    saveData.CutSceneFlagBundle2.unknown29 = 1;
-    saveData.CutSceneFlagBundle2.unknown30 = 1;
-    saveData.CutSceneFlagBundle2.unknown31 = 0;
+    //Road to Woodfall: 
+    //0x12D9 = 0x08
+    saveData.RoadtoWoodfallCameraPan_0x08 = 0x08;
+    
+    //Pirate's fortress exterior:
+    //0x09B5 = 0x04
+    saveData.PiratesFortressExteriorCameraPan_0x04 = 0x04;
 
-    saveData.anonymous_128 = 0x20;
-      
+    //Ikana Castle from canyon: 
+    //0x05F4 = 0x08
+    //saveData.gap249[931] = 0x08; //<- this gets rid of the Sunblock
+    //0x05FB = 0x80
+    saveData.IkanaCastleCameraPan_0x08 = 0x80;
   } 
   //Resolve the item ID for the starting bottle
   static void SaveFile_GiveStartingBottle(StartingBottleSetting startingBottle, u8 bottleSlot) {

--- a/code/source/rnd/savefile.cpp
+++ b/code/source/rnd/savefile.cpp
@@ -145,57 +145,57 @@ namespace rnd {
     
     //Addresses 0x1250 to 0x1253
     //saveData.event_reg_maybe = 0xFE; as 1111 1110 in savefile
-    //saveData.CutSceneFlagBundle1.unknown0 = 0;
-    saveData.CutSceneFlagBundle1.termina_field = 1;
-    saveData.CutSceneFlagBundle1.graveyard = 1;
-    saveData.CutSceneFlagBundle1.romani_ranch = 1;
-    saveData.CutSceneFlagBundle1.gorman_track = 1;
-    saveData.CutSceneFlagBundle1.mountain_village = 1;
-    saveData.CutSceneFlagBundle1.goron_city = 1;
-    saveData.CutSceneFlagBundle1.snowhead = 1;
+    //saveData.cut_scene_flag_bundle1.unknown0 = 0;
+    saveData.cut_scene_flag_bundle1.termina_field = 1;
+    saveData.cut_scene_flag_bundle1.graveyard = 1;
+    saveData.cut_scene_flag_bundle1.romani_ranch = 1;
+    saveData.cut_scene_flag_bundle1.gorman_track = 1;
+    saveData.cut_scene_flag_bundle1.mountain_village = 1;
+    saveData.cut_scene_flag_bundle1.goron_city = 1;
+    saveData.cut_scene_flag_bundle1.snowhead = 1;
 
     //saveData.anonymous_69 = 0xFF;
-    saveData.CutSceneFlagBundle1.southern_swamp = 1;
-    saveData.CutSceneFlagBundle1.woodfall = 1;
-    saveData.CutSceneFlagBundle1.deku_palace = 1;
-    saveData.CutSceneFlagBundle1.great_bay_coast = 1;
-    saveData.CutSceneFlagBundle1.pirates_fortress = 1;
-    saveData.CutSceneFlagBundle1.zora_domain = 1;
-    saveData.CutSceneFlagBundle1.waterfall_rapids = 1;
-    saveData.CutSceneFlagBundle1.ikana_canyon = 1;
+    saveData.cut_scene_flag_bundle1.southern_swamp = 1;
+    saveData.cut_scene_flag_bundle1.woodfall = 1;
+    saveData.cut_scene_flag_bundle1.deku_palace = 1;
+    saveData.cut_scene_flag_bundle1.great_bay_coast = 1;
+    saveData.cut_scene_flag_bundle1.pirates_fortress = 1;
+    saveData.cut_scene_flag_bundle1.zora_domain = 1;
+    saveData.cut_scene_flag_bundle1.waterfall_rapids = 1;
+    saveData.cut_scene_flag_bundle1.ikana_canyon = 1;
 
     //saveData.anonymous_70 = 0xFE; as 1111 1110 in savefile
-    //saveData.CutSceneFlagBundle1.unknown16 = 0;
-    saveData.CutSceneFlagBundle1.stone_tower = 1;
-    saveData.CutSceneFlagBundle1.stone_tower_inverted = 1;
-    saveData.CutSceneFlagBundle1.east_clock_town = 1;
-    saveData.CutSceneFlagBundle1.west_clock_town = 1;
-    saveData.CutSceneFlagBundle1.north_clock_town = 1;
-    saveData.CutSceneFlagBundle1.woodfall_temple = 1;
-    saveData.CutSceneFlagBundle1.snowhead_temple = 1;
+    //saveData.cut_scene_flag_bundle1.unknown16 = 0;
+    saveData.cut_scene_flag_bundle1.stone_tower = 1;
+    saveData.cut_scene_flag_bundle1.stone_tower_inverted = 1;
+    saveData.cut_scene_flag_bundle1.east_clock_town = 1;
+    saveData.cut_scene_flag_bundle1.west_clock_town = 1;
+    saveData.cut_scene_flag_bundle1.north_clock_town = 1;
+    saveData.cut_scene_flag_bundle1.woodfall_temple = 1;
+    saveData.cut_scene_flag_bundle1.snowhead_temple = 1;
 
     //saveData.gap1253 = 0x06; written as 0000 0110 in savefile
-    //saveData.CutSceneFlagBundle1.unknown24 = 0;
-    saveData.CutSceneFlagBundle1.stone_tower_temple = 1; 
-    saveData.CutSceneFlagBundle1.stone_tower_temple_inverted = 1;  
-    //saveData.CutSceneFlagBundle1.unknown27 = 0;
-    //saveData.CutSceneFlagBundle1.unknown28 = 0;
-    //saveData.CutSceneFlagBundle1.unknown29 = 0;
-    //saveData.CutSceneFlagBundle1.unknown30 = 0;
-    //saveData.CutSceneFlagBundle1.unknown31 = 0;
+    //saveData.cut_scene_flag_bundle1.unknown24 = 0;
+    saveData.cut_scene_flag_bundle1.stone_tower_temple = 1; 
+    saveData.cut_scene_flag_bundle1.stone_tower_temple_inverted = 1;  
+    //saveData.cut_scene_flag_bundle1.unknown27 = 0;
+    //saveData.cut_scene_flag_bundle1.unknown28 = 0;
+    //saveData.cut_scene_flag_bundle1.unknown29 = 0;
+    //saveData.cut_scene_flag_bundle1.unknown30 = 0;
+    //saveData.cut_scene_flag_bundle1.unknown31 = 0;
     
     //GreatbayTemple not in bundle above, does not seem to have a camera pan scene
 
     //ClockTown Owl statue: 0x12D3 = 0x10
     //saveData.anonymous_152_saved_once_0x10_sot_once_0x40 = 0x11;// 0x01 is deku palace
-    saveData.CutSceneFlagBundle2.owl_statue_cut_scene = 1;
-    //saveData.CutSceneFlagBundle2.unknown1 = 0;
-    //saveData.CutSceneFlagBundle2.unknown2 = 0;
-    //saveData.CutSceneFlagBundle2.unknown3 = 0;
-    saveData.CutSceneFlagBundle2.deku_palace_throne_room_cutscene = 1;
-    //saveData.CutSceneFlagBundle2.unknown5 = 0;
-    //saveData.CutSceneFlagBundle2.unknown6 = 0;
-    //saveData.CutSceneFlagBundle2.unknown7 = 0;
+    saveData.cut_scene_flag_bundle2.owl_statue_cut_scene = 1;
+    //saveData.cut_scene_flag_bundle2.unknown1 = 0;
+    //saveData.cut_scene_flag_bundle2.unknown2 = 0;
+    //saveData.cut_scene_flag_bundle2.unknown3 = 0;
+    saveData.cut_scene_flag_bundle2.deku_palace_throne_room_cutscene = 1;
+    //saveData.cut_scene_flag_bundle2.unknown5 = 0;
+    //saveData.cut_scene_flag_bundle2.unknown6 = 0;
+    //saveData.cut_scene_flag_bundle2.unknown7 = 0;
 
     //Meeting the Happy Mask Salesman: 
     //0x0EB4 = 0x01

--- a/code/source/rnd/savefile.cpp
+++ b/code/source/rnd/savefile.cpp
@@ -17,8 +17,7 @@ namespace rnd {
     game::SaveData &saveData = game::GetCommonData().save;
 #ifdef ENABLE_DEBUG
     //rnd::util::Print("%s: Made it to save debug values.", __func__);
-    saveData.equipment.sword_shield.sword = game::SwordType::GildedSword;
-    saveData.player.razor_sword_hp = 0x64;
+    saveData.equipment.sword_shield.sword = game::SwordType::RazorSword;
     saveData.inventory.inventory_count_register.quiver_upgrade = game::Quiver::Quiver50;
     saveData.inventory.inventory_count_register.bomb_bag_upgrade = game::BombBag::BombBag40;
     saveData.inventory.inventory_count_register.wallet_upgrade = 2;
@@ -41,6 +40,8 @@ namespace rnd {
     saveData.inventory.masks[2] = game::ItemId::ZoraMask;
     saveData.inventory.masks[3] = game::ItemId::FierceDeityMask;
     saveData.inventory.masks[4] = game::ItemId::GibdoMask;
+    saveData.inventory.masks[5] = game::ItemId::BunnyHood;
+    saveData.inventory.masks[6] = game::ItemId::GaroMask;
 
     saveData.inventory.woodfall_temple_keys = 8;
     saveData.inventory.snowhead_temple_keys = 8;
@@ -59,7 +60,7 @@ namespace rnd {
     saveData.inventory.stone_tower_dungeon_items.compass = 1;
     saveData.inventory.stone_tower_dungeon_items.boss_key = 1;
     saveData.player.magic_acquired = 1;
-    saveData.player.magic_size_type = 0;
+    saveData.player.magic_size_type = 2; //not init until saved?
     saveData.player.magic = 96;
     saveData.player.magic_num_upgrades = 1;
     saveData.equipment.data[3].item_btns[0] = game::ItemId::DekuNuts;
@@ -69,24 +70,127 @@ namespace rnd {
     saveData.inventory.item_counts[14] = 20; // Nuts
     saveData.inventory.item_counts[13] = 20; // Sticks
     saveData.has_great_spin_0x02 = 2;             // Set great spin.
+
+    saveData.player.owl_statue_flags.great_bay = 1;
+    saveData.player.owl_statue_flags.zora_cape = 1;
+    saveData.player.owl_statue_flags.snowhead = 1;
+    saveData.player.owl_statue_flags.mountain_village = 1;
+    saveData.player.owl_statue_flags.woodfall = 1;
+    saveData.player.owl_statue_flags.ikana_canyon = 1;
+    saveData.player.owl_statue_flags.stone_tower = 1;
+
+    saveData.inventory.collect_register.sonata_of_awakening = 1;
+    saveData.inventory.collect_register.goron_lullaby = 1;
+    saveData.inventory.collect_register.new_wave_bossa_nova = 1;
+    saveData.inventory.collect_register.elegy_of_emptiness = 1;
+    saveData.inventory.collect_register.eponas_song = 1;
+
+    //extra/temp testing items
+    saveData.inventory.collect_register.sarias_song = 1;
 #endif
     //TODO: Decomp event flags. Most likely in the large anonymous structs in the SaveData.
     u8 isNewFile = saveData.has_completed_intro;
     if (isNewFile == 0) {
       saveData.has_completed_intro = 0x2B;
+      saveData.inventory.items[0] = game::ItemId::Ocarina;
+      saveData.player.razor_sword_hp = 0xFFFF;
+
+
+      //TODO Time Savers:
+      //Bomber's minigame skip
+      //Allow first time transformation to be skipable
+      //Find flag for navi diologue at woodfall temple entrance platform
+      //Find flag for navi diologue at snowhead entrance
+      //Faster dungeon cutscene for swamp, mountain and zora
+      //Fast songs works but needs to be applied to first time played too
+      //skip Ikana king diolouge intro
+      //skip pushing zora to shore
+      //skip pirate leader diologue
+
+      //Mass cutscene skip attemps
+      //found a potential bitfeild for a large number of camera pan cutscenes
+      //0x1250 to 0x1253 and 0x12F0 to 0x12F4
+      //Have yet to decipher which bits correspond to what cutscene
+      //failed at deku palace interior
+      //failed at ikana castle
+      
+      saveData.event_reg_maybe = 0xFE;
+      saveData.anonymous_69 = 0xFF;
+      saveData.anonymous_70 = 0xFE;
+      saveData.gap1253[0] = 0x06;
+
+      saveData.anonymous_161 = 0x7FEFEF1D;
+      saveData.anonymous_128 = 0x20;
+      
+      //Cutscene skip comment explanation:
+      //name_of_cutscene: offset_address_in_save_file = value_in_hex
+      //offest address in save file has a quivalent address in save struct
+
+      //deku palace interior: 
+      //0x0A28 = 0x01 and 0x0A2C = 0x10
+      //0x07C8 = 0x01 and 0x07CC = 0x10 
+      saveData.gap8A9[383] = 0x01;
+      saveData.gap8A9[387] = 0x10;
+      saveData.gap728[160] = 0x01;
+      saveData.gap728[164] = 0x10;
+
+      //Road to Woodfall: 0x12D9 = 0x08 or 0000 1000
+      saveData.anonymous_158 = 0x08;
+
+      //Ikana Castle: 0x05F4 = 0x08 and 0x05F8 = 0x80
+      //0x125C = 0xB0 <- the front bit got flipped
+      saveData.gap249[931] = 0x08;
+      saveData.gap249[935] = 0x80;
+      saveData.anonymous_75 = 0xB0;
+
+      //Meeting the Happy Mask Salesman: 0x0EB4 = 0x01, 0x0EC8 = 0x01
+      //0x0ECC = 0x10,
+
+      saveData.gapCAC[520] = 0x01;
+      saveData.gapCAC[540] = 0x01;
+      saveData.gapCAC[544] = 0x10;
+
+      //ClockTown Owl statue: 0x12AC = 0x80, 0x12D3 = 0x10 
+      saveData.anonymous_140 = 0x80;
+      saveData.anonymous_152_saved_once_0x10_sot_once_0x40 = 0x10;
+
+      //SkullKid backstory cutscene: 0x07F4 = 0x10 and 0x12F3 = 10
+      //0x0F08 = 0x04 and 0x0F0C = 0x10
+      saveData.gap728[204] = 0x10;
+      saveData.anonymous_162 = 0x10;
+      saveData.gapCAC[604] = 0x04;
+      saveData.gapCAC[608] = 0x10;
+
+
+      saveData.ct_guard_allows_through_if_0x30 = 0x30;
+
+      //Preinitialized owl statues
+      saveData.player.owl_statue_flags.clock_town = 1;
+      saveData.player.owl_statue_flags.milk_road = 1;
+      saveData.player.owl_statue_flags.southern_swamp = 1;
+
       saveData.inventory.collect_register.bombers_notebook = 1;
-      saveData.inventory.collect_register.song_of_healing = 1;
+      saveData.inventory.collect_register.song_of_time = 1;
+
+      //Soaring can stay default until songsanity works
+      saveData.inventory.collect_register.song_of_soaring = 1;
+
       saveData.has_tatl = true;
       saveData.ct_deku_flown_in_0x80_if_visited_once = 0x80;
       saveData.ct_deku_in_flower_0x04_if_present = 0x04;
       saveData.skip_tatl_talking_0x04 = 0x04;
+      //saveData.player.tatl_timer_maybe = 0x1000;
+      //saveData.ct_deku_removed_if_c0 = 0xC0;
+      saveData.player_form = game::act::Player::Form::Human;
+
+      /*
       #ifdef ENABLE_DEBUG
       saveData.player_form = game::act::Player::Form::Human;
       #else
       saveData.player_form = game::act::Player::Form::Deku;
       #endif
+      */
       //game::GiveItem(game::ItemId::BombersNotebook);
-      //TODO: Things to set on
     }
     
   }

--- a/code/source/rnd/savefile.cpp
+++ b/code/source/rnd/savefile.cpp
@@ -34,6 +34,7 @@ namespace rnd {
     saveData.inventory.items[10] = game::ItemId::DekuStick;
     saveData.inventory.items[13] = game::ItemId::PictographBox;
     saveData.inventory.items[15] = game::ItemId::Hookshot;
+    saveData.inventory.items[16] = game::ItemId::PowderKeg;
 
     saveData.inventory.masks[0] = game::ItemId::DekuMask;
     saveData.inventory.masks[1] = game::ItemId::GoronMask;
@@ -59,10 +60,10 @@ namespace rnd {
     saveData.inventory.stone_tower_dungeon_items.map = 1;
     saveData.inventory.stone_tower_dungeon_items.compass = 1;
     saveData.inventory.stone_tower_dungeon_items.boss_key = 1;
-    saveData.player.magic_acquired = 1;
-    saveData.player.magic_size_type = 2; //not init until saved?
-    saveData.player.magic = 96;
-    saveData.player.magic_num_upgrades = 1;
+    //saveData.player.magic_acquired = 1;
+    //saveData.player.magic_size_type = 2; //not init until saved?
+    //saveData.player.magic = 96;
+    //saveData.player.magic_num_upgrades = 1;
     saveData.equipment.data[3].item_btns[0] = game::ItemId::DekuNuts;
     saveData.inventory.item_counts[6] = 50;  // Arrows
     saveData.inventory.item_counts[11] = 40; // Bombs
@@ -107,20 +108,8 @@ namespace rnd {
       //skip pushing zora to shore
       //skip pirate leader diologue
 
-      //Mass cutscene skip attemps
-      //found a potential bitfeild for a large number of camera pan cutscenes
-      //0x1250 to 0x1253 and 0x12F0 to 0x12F4
-      //Have yet to decipher which bits correspond to what cutscene
-      //failed at deku palace interior
-      //failed at ikana castle
-      
-      saveData.event_reg_maybe = 0xFE;
-      saveData.anonymous_69 = 0xFF;
-      saveData.anonymous_70 = 0xFE;
-      saveData.gap1253[0] = 0x06;
-
-      saveData.anonymous_161 = 0x7FEFEF1D;
-      saveData.anonymous_128 = 0x20;
+      //Mass cutscene skip attemp
+      MassCutSceneSkip();
       
       //Cutscene skip comment explanation:
       //name_of_cutscene: offset_address_in_save_file = value_in_hex
@@ -134,14 +123,20 @@ namespace rnd {
       saveData.gap728[160] = 0x01;
       saveData.gap728[164] = 0x10;
 
-      //Road to Woodfall: 0x12D9 = 0x08 or 0000 1000
+      //Road to Woodfall: 0x12D9 = 0x08, read as 1000 0000 in game
       saveData.anonymous_158 = 0x08;
 
-      //Ikana Castle: 0x05F4 = 0x08 and 0x05F8 = 0x80
-      //0x125C = 0xB0 <- the front bit got flipped
-      saveData.gap249[931] = 0x08;
-      saveData.gap249[935] = 0x80;
-      saveData.anonymous_75 = 0xB0;
+      //Ikana Castle from canyon: 0x04C8 = 0x01 and 0x04CC = 0x08
+      //0x05F4 = 0x08, 0x05FB = 0x80
+      //0x0604 = 0x01, 0x0608 = 0x04
+      saveData.gap249[955] = 0x01;
+      saveData.gap249[959] = 0x04;
+      //0x1048 = 0x01, 0x104C = 0x10
+      saveData.gapCAC[924] = 0x01;
+      saveData.gapCAC[928] = 0x10;
+      //0x128B = 0x05, 0x012DC = 0x88
+      saveData.skip_tatl_talking_0x04 = 0x05;
+      saveData.ct_deku_flown_in_0x80_if_visited_once = 0x88;
 
       //Meeting the Happy Mask Salesman: 0x0EB4 = 0x01, 0x0EC8 = 0x01
       //0x0ECC = 0x10,
@@ -176,9 +171,9 @@ namespace rnd {
       saveData.inventory.collect_register.song_of_soaring = 1;
 
       saveData.has_tatl = true;
-      saveData.ct_deku_flown_in_0x80_if_visited_once = 0x80;
+      //saveData.ct_deku_flown_in_0x80_if_visited_once = 0x80;
       saveData.ct_deku_in_flower_0x04_if_present = 0x04;
-      saveData.skip_tatl_talking_0x04 = 0x04;
+      //saveData.skip_tatl_talking_0x04 = 0x04;
       //saveData.player.tatl_timer_maybe = 0x1000;
       //saveData.ct_deku_removed_if_c0 = 0xC0;
       saveData.player_form = game::act::Player::Form::Human;
@@ -195,6 +190,102 @@ namespace rnd {
     
   }
 
+  void MassCutSceneSkip() {
+    game::SaveData &saveData = game::GetCommonData().save;
+    //found a potential bitfeild for a large number of camera pan cutscenes
+    //Have yet to decipher which bits correspond to what cutscene
+
+    //failed at pirate fortress exterior
+    //failed at deku palace interior
+    //failed at ikana castle
+
+    /*
+    //0x1250 to 0x1253
+    saveData.event_reg_maybe = 0xFE; written as 0111 1111 in bitfield/savefile
+    saveData.anonymous_69 = 0xFF;
+    saveData.anonymous_70 = 0xFE;
+    saveData.gap1253 = 0x06; written as 0110 0000 in bitfield/savefile
+    */
+
+    saveData.CutSceneFlagBundle1.unknown0 = 0;
+    saveData.CutSceneFlagBundle1.unknown1 = 1;
+    saveData.CutSceneFlagBundle1.unknown2 = 1;
+    saveData.CutSceneFlagBundle1.unknown3 = 1;
+    saveData.CutSceneFlagBundle1.unknown4 = 1;
+    saveData.CutSceneFlagBundle1.unknown5 = 1;
+    saveData.CutSceneFlagBundle1.unknown6 = 1;
+    saveData.CutSceneFlagBundle1.unknown7 = 1;
+
+    saveData.CutSceneFlagBundle1.unknown8 = 1;
+    saveData.CutSceneFlagBundle1.unknown9 = 1;
+    saveData.CutSceneFlagBundle1.unknown10 = 1;
+    saveData.CutSceneFlagBundle1.unknown11 = 1;
+    saveData.CutSceneFlagBundle1.unknown12 = 1;
+    saveData.CutSceneFlagBundle1.unknown13 = 1;
+    saveData.CutSceneFlagBundle1.unknown14 = 1;
+    saveData.CutSceneFlagBundle1.unknown15 = 1;
+
+    saveData.CutSceneFlagBundle1.unknown16 = 0;
+    saveData.CutSceneFlagBundle1.unknown17 = 1;
+    saveData.CutSceneFlagBundle1.unknown18 = 1;
+    saveData.CutSceneFlagBundle1.unknown19 = 1;
+    saveData.CutSceneFlagBundle1.unknown20 = 1;
+    saveData.CutSceneFlagBundle1.unknown21 = 1;
+    saveData.CutSceneFlagBundle1.unknown22 = 1;
+    saveData.CutSceneFlagBundle1.unknown23 = 1;
+
+    saveData.CutSceneFlagBundle1.unknown24 = 0;
+    saveData.CutSceneFlagBundle1.unknown25 = 1;
+    saveData.CutSceneFlagBundle1.unknown26 = 1;
+    saveData.CutSceneFlagBundle1.unknown27 = 0;
+    saveData.CutSceneFlagBundle1.unknown28 = 0;
+    saveData.CutSceneFlagBundle1.unknown29 = 0;
+    saveData.CutSceneFlagBundle1.unknown30 = 0;
+    saveData.CutSceneFlagBundle1.unknown31 = 0;
+    
+    //0x12F0 to 0x12F4
+    //saveData.anonymous_161 = 0x7F EF EF 7F;
+    // written as 1111 1110   1111 0111   1111 0111   1111 1110 in bitfield/savefile
+
+    saveData.CutSceneFlagBundle2.unknown0 = 1;
+    saveData.CutSceneFlagBundle2.unknown1 = 1;
+    saveData.CutSceneFlagBundle2.unknown2 = 1;
+    saveData.CutSceneFlagBundle2.unknown3 = 1;
+    saveData.CutSceneFlagBundle2.unknown4 = 1;
+    saveData.CutSceneFlagBundle2.unknown5 = 1;
+    saveData.CutSceneFlagBundle2.unknown6 = 1;
+    saveData.CutSceneFlagBundle2.unknown7 = 0;
+
+    saveData.CutSceneFlagBundle2.unknown8 = 1;
+    saveData.CutSceneFlagBundle2.unknown9 = 1;
+    saveData.CutSceneFlagBundle2.unknown10 = 1;
+    saveData.CutSceneFlagBundle2.unknown11 = 1;
+    saveData.CutSceneFlagBundle2.unknown12 = 0;
+    saveData.CutSceneFlagBundle2.unknown13 = 1;
+    saveData.CutSceneFlagBundle2.unknown14 = 1;
+    saveData.CutSceneFlagBundle2.unknown15 = 1;
+
+    saveData.CutSceneFlagBundle2.unknown16 = 1;
+    saveData.CutSceneFlagBundle2.unknown17 = 1;
+    saveData.CutSceneFlagBundle2.unknown18 = 1;
+    saveData.CutSceneFlagBundle2.unknown19 = 1;
+    saveData.CutSceneFlagBundle2.unknown20 = 0;
+    saveData.CutSceneFlagBundle2.unknown21 = 1;
+    saveData.CutSceneFlagBundle2.unknown22 = 1;
+    saveData.CutSceneFlagBundle2.unknown23 = 1;
+
+    saveData.CutSceneFlagBundle2.unknown24 = 1;
+    saveData.CutSceneFlagBundle2.unknown25 = 1;
+    saveData.CutSceneFlagBundle2.unknown26 = 1;
+    saveData.CutSceneFlagBundle2.unknown27 = 1;
+    saveData.CutSceneFlagBundle2.unknown28 = 1;
+    saveData.CutSceneFlagBundle2.unknown29 = 1;
+    saveData.CutSceneFlagBundle2.unknown30 = 1;
+    saveData.CutSceneFlagBundle2.unknown31 = 0;
+
+    saveData.anonymous_128 = 0x20;
+      
+  } 
   //Resolve the item ID for the starting bottle
   static void SaveFile_GiveStartingBottle(StartingBottleSetting startingBottle, u8 bottleSlot) {
     game::SaveData &saveData = game::GetCommonData().save;

--- a/code/source/rnd/savefile.cpp
+++ b/code/source/rnd/savefile.cpp
@@ -17,7 +17,8 @@ namespace rnd {
     game::SaveData &saveData = game::GetCommonData().save;
 #ifdef ENABLE_DEBUG
     //rnd::util::Print("%s: Made it to save debug values.", __func__);
-    saveData.equipment.sword_shield.sword = game::SwordType::RazorSword;
+    saveData.equipment.sword_shield.sword = game::SwordType::GildedSword;
+    saveData.player.razor_sword_hp = 0x64;
     saveData.inventory.inventory_count_register.quiver_upgrade = game::Quiver::Quiver50;
     saveData.inventory.inventory_count_register.bomb_bag_upgrade = game::BombBag::BombBag40;
     saveData.inventory.inventory_count_register.wallet_upgrade = 2;
@@ -60,23 +61,26 @@ namespace rnd {
     saveData.inventory.stone_tower_dungeon_items.map = 1;
     saveData.inventory.stone_tower_dungeon_items.compass = 1;
     saveData.inventory.stone_tower_dungeon_items.boss_key = 1;
-    //saveData.player.magic_acquired = 1;
-    //saveData.player.magic_size_type = 2; //not init until saved?
-    //saveData.player.magic = 96;
-    //saveData.player.magic_num_upgrades = 1;
+    saveData.player.magic_acquired = 1; //Game does not check if value = 0, magic items still work
+    saveData.player.magic_size_type = 2; //not init until saved?
+    saveData.player.magic = 96;
+    saveData.player.magic_num_upgrades = 1;
     saveData.equipment.data[3].item_btns[0] = game::ItemId::DekuNuts;
     saveData.inventory.item_counts[6] = 50;  // Arrows
     saveData.inventory.item_counts[11] = 40; // Bombs
     saveData.inventory.item_counts[12] = 40; // Bombchus
     saveData.inventory.item_counts[14] = 20; // Nuts
     saveData.inventory.item_counts[13] = 20; // Sticks
-    saveData.has_great_spin_0x02 = 2;             // Set great spin.
+    saveData.has_great_spin_0x02 = 2;        // Set great spin.
 
     saveData.player.owl_statue_flags.great_bay = 1;
     saveData.player.owl_statue_flags.zora_cape = 1;
     saveData.player.owl_statue_flags.snowhead = 1;
     saveData.player.owl_statue_flags.mountain_village = 1;
+    saveData.player.owl_statue_flags.clock_town = 1;
+    saveData.player.owl_statue_flags.milk_road = 1;
     saveData.player.owl_statue_flags.woodfall = 1;
+    saveData.player.owl_statue_flags.southern_swamp = 1;
     saveData.player.owl_statue_flags.ikana_canyon = 1;
     saveData.player.owl_statue_flags.stone_tower = 1;
 
@@ -85,16 +89,15 @@ namespace rnd {
     saveData.inventory.collect_register.new_wave_bossa_nova = 1;
     saveData.inventory.collect_register.elegy_of_emptiness = 1;
     saveData.inventory.collect_register.eponas_song = 1;
+    saveData.inventory.collect_register.song_of_soaring = 1;
+    saveData.inventory.collect_register.song_of_time = 1;
 
     //extra/temp testing items
-    //saveData.inventory.collect_register.sarias_song = 1;
+    
 #endif
     //TODO: Decomp event flags. Most likely in the large anonymous structs in the SaveData.
     u8 isNewFile = saveData.has_completed_intro;
     if (isNewFile == 0) {
-      saveData.has_completed_intro = 0x2B;
-      saveData.inventory.items[0] = game::ItemId::Ocarina;
-
       //TODO Time Savers:
       //Bomber's minigame skip ie. open hideout
       //Allow first time transformation to be skipable
@@ -105,75 +108,76 @@ namespace rnd {
       //skip Ikana king diolouge intro
       //skip pushing zora to shore
       //skip pirate leader diologue
+      //Skip all giants cutscenes except for woodfall
+      //Boss warp skipping the boss fight entirely
 
       //Skips cutscenes with no item checks attached
       //Also does not skip location access cutscenes like woodfall temple rise
-      MassCutSceneSkip();
+      SaveFile_SkipMinorCutscenes();
 
-      saveData.ct_guard_allows_through_if_0x30 = 0x30;
+      //OOT equivalent of starting with certain warp songs
+      SaveFile_SetStartingOwlStatues(); //still needs to be fully added to options
 
-      //Preinitialized owl statues
-      saveData.player.owl_statue_flags.clock_town = 1;
-      saveData.player.owl_statue_flags.milk_road = 1;
-      saveData.player.owl_statue_flags.southern_swamp = 1;
-
-      saveData.inventory.collect_register.bombers_notebook = 1;
-      saveData.inventory.collect_register.song_of_time = 1;
-
-      //Soaring can stay default until songsanity works
-      saveData.inventory.collect_register.song_of_soaring = 1;
+      //Currently starting with ocarina and song of time is default in MM rando
+      //These two items allows for skipping the first three day cycle
+      saveData.inventory.collect_register.song_of_time = 1; //Part of starting equipment options
+      saveData.inventory.items[0] = game::ItemId::Ocarina; //Part of starting quest items options
+      //SaveFile_SetStartingInventory();
 
       saveData.has_tatl = true;
+      saveData.has_completed_intro = 0x2B;
       saveData.ct_deku_flown_in_0x80_if_visited_once = 0x80;
       saveData.ct_deku_in_flower_0x04_if_present = 0x04;
       saveData.skip_tatl_talking_0x04 = 0x04;
+
+      //This flag gets reset by song of time
+      saveData.ct_guard_allows_through_if_0x30 = 0x30;
+
       //saveData.player.tatl_timer_maybe = 0x1000;
-      //saveData.ct_deku_removed_if_c0 = 0xC0;
       saveData.player_form = game::act::Player::Form::Human;
-      //game::GiveItem(game::ItemId::BombersNotebook);
     }
     
   }
 
-  void MassCutSceneSkip() {
+  void SaveFile_SkipMinorCutscenes() {
     game::SaveData &saveData = game::GetCommonData().save;
     //addresses listed in comments is where it is in the savefile
     
     //Addresses 0x1250 to 0x1253
     //saveData.event_reg_maybe = 0xFE; as 1111 1110 in savefile
     //saveData.CutSceneFlagBundle1.unknown0 = 0;
-    saveData.CutSceneFlagBundle1.TerminaField = 1;
-    saveData.CutSceneFlagBundle1.Graveyard = 1;
-    saveData.CutSceneFlagBundle1.RomaniRanch = 1;
-    saveData.CutSceneFlagBundle1.GormanTrack = 1;
-    saveData.CutSceneFlagBundle1.MountainVillage = 1;
-    saveData.CutSceneFlagBundle1.GoronCity = 1;
-    saveData.CutSceneFlagBundle1.Snowhead = 1;
+    saveData.CutSceneFlagBundle1.termina_field = 1;
+    saveData.CutSceneFlagBundle1.graveyard = 1;
+    saveData.CutSceneFlagBundle1.romani_ranch = 1;
+    saveData.CutSceneFlagBundle1.gorman_track = 1;
+    saveData.CutSceneFlagBundle1.mountain_village = 1;
+    saveData.CutSceneFlagBundle1.goron_city = 1;
+    saveData.CutSceneFlagBundle1.snowhead = 1;
 
     //saveData.anonymous_69 = 0xFF;
-    saveData.CutSceneFlagBundle1.SouthernSwamp = 1;
-    saveData.CutSceneFlagBundle1.Woodfall = 1;
-    saveData.CutSceneFlagBundle1.DekuPalace = 1;
-    saveData.CutSceneFlagBundle1.GreatBayCoast = 1;
-    saveData.CutSceneFlagBundle1.PiratesFortress = 1;
-    saveData.CutSceneFlagBundle1.ZoraDomain = 1;
-    saveData.CutSceneFlagBundle1.WaterfallRapids = 1;
-    saveData.CutSceneFlagBundle1.IkanaCanyon = 1;
+    saveData.CutSceneFlagBundle1.southern_swamp = 1;
+    saveData.CutSceneFlagBundle1.woodfall = 1;
+    saveData.CutSceneFlagBundle1.deku_palace = 1;
+    saveData.CutSceneFlagBundle1.great_bay_coast = 1;
+    saveData.CutSceneFlagBundle1.pirates_fortress = 1;
+    saveData.CutSceneFlagBundle1.zora_domain = 1;
+    saveData.CutSceneFlagBundle1.waterfall_rapids = 1;
+    saveData.CutSceneFlagBundle1.ikana_canyon = 1;
 
     //saveData.anonymous_70 = 0xFE; as 1111 1110 in savefile
     //saveData.CutSceneFlagBundle1.unknown16 = 0;
-    saveData.CutSceneFlagBundle1.StoneTower = 1;
-    saveData.CutSceneFlagBundle1.StoneTowerInverted = 1;
-    saveData.CutSceneFlagBundle1.EastClockTown = 1;
-    saveData.CutSceneFlagBundle1.WestClockTown = 1;
-    saveData.CutSceneFlagBundle1.NorthClockTown = 1;
-    saveData.CutSceneFlagBundle1.WoodfallTemple = 1;
-    saveData.CutSceneFlagBundle1.SnowheadTemple = 1;
+    saveData.CutSceneFlagBundle1.stone_tower = 1;
+    saveData.CutSceneFlagBundle1.stone_tower_inverted = 1;
+    saveData.CutSceneFlagBundle1.east_clock_town = 1;
+    saveData.CutSceneFlagBundle1.west_clock_town = 1;
+    saveData.CutSceneFlagBundle1.north_clock_town = 1;
+    saveData.CutSceneFlagBundle1.woodfall_temple = 1;
+    saveData.CutSceneFlagBundle1.snowhead_temple = 1;
 
     //saveData.gap1253 = 0x06; written as 0000 0110 in savefile
     //saveData.CutSceneFlagBundle1.unknown24 = 0;
-    saveData.CutSceneFlagBundle1.StoneTowerTemple = 1; 
-    saveData.CutSceneFlagBundle1.StoneTowerTempleInverted = 1;  
+    saveData.CutSceneFlagBundle1.stone_tower_temple = 1; 
+    saveData.CutSceneFlagBundle1.stone_tower_temple_inverted = 1;  
     //saveData.CutSceneFlagBundle1.unknown27 = 0;
     //saveData.CutSceneFlagBundle1.unknown28 = 0;
     //saveData.CutSceneFlagBundle1.unknown29 = 0;
@@ -184,37 +188,48 @@ namespace rnd {
 
     //ClockTown Owl statue: 0x12D3 = 0x10
     //saveData.anonymous_152_saved_once_0x10_sot_once_0x40 = 0x11;// 0x01 is deku palace
-    saveData.CutSceneFlagBundle2.OwlStatueCutScene = 1;
+    saveData.CutSceneFlagBundle2.owl_statue_cut_scene = 1;
     //saveData.CutSceneFlagBundle2.unknown1 = 0;
     //saveData.CutSceneFlagBundle2.unknown2 = 0;
     //saveData.CutSceneFlagBundle2.unknown3 = 0;
-    saveData.CutSceneFlagBundle2.DekuPalaceThroneRoomCutScene = 1;
+    saveData.CutSceneFlagBundle2.deku_palace_throne_room_cutscene = 1;
     //saveData.CutSceneFlagBundle2.unknown5 = 0;
     //saveData.CutSceneFlagBundle2.unknown6 = 0;
     //saveData.CutSceneFlagBundle2.unknown7 = 0;
 
     //Meeting the Happy Mask Salesman: 
     //0x0EB4 = 0x01
-    saveData.MeetingTheHappyMaskMan_0x01 = 0x01;
+    saveData.meeting_happy_mask_salesman_0x01 = 0x01;
 
     //SkullKid backstory cutscene:
     //0x07F4 = 0x10 
-    saveData.SkullKidBackstoryCutscene_0x10 = 0x10;
+    saveData.skullkid_backstory_cutscene_0x10 = 0x10;
 
     //Road to Woodfall: 
     //0x12D9 = 0x08
-    saveData.RoadtoWoodfallCameraPan_0x08 = 0x08;
+    saveData.road_to_woodfall_camera_pan_0x08 = 0x08;
     
     //Pirate's fortress exterior:
     //0x09B5 = 0x04
-    saveData.PiratesFortressExteriorCameraPan_0x04 = 0x04;
+    saveData.pirates_fortress_exterior_camera_pan_0x04 = 0x04;
 
     //Ikana Castle from canyon: 
     //0x05F4 = 0x08
     //saveData.gap249[931] = 0x08; //<- this gets rid of the Sunblock
     //0x05FB = 0x80
-    saveData.IkanaCastleCameraPan_0x08 = 0x80;
+    saveData.ikana_castle_camera_pan_0x08 = 0x80;
   } 
+  void SaveFile_SetStartingOwlStatues() {
+      //future comfort option
+      /*
+      if(gSettingsContext.startingOwlStatues.ClockTown)
+      saveData.player.owl_statue_flags.clock_town = 1;
+      else if(gSettingsContext.startingOwlStatues.MilkRoad)
+      saveData.player.owl_statue_flags.milk_road = 1;
+      else if(gSettingsContext.startingOwlStatues.SouthernSwamp)
+      saveData.player.owl_statue_flags.southern_swamp = 1;
+      */
+  }
   //Resolve the item ID for the starting bottle
   static void SaveFile_GiveStartingBottle(StartingBottleSetting startingBottle, u8 bottleSlot) {
     game::SaveData &saveData = game::GetCommonData().save;


### PR DESCRIPTION
Most, if not all, camera panning cut scenes have been found and skipped properly, with a single bit toggle for all cut scenes.
Plus the scenes for: Clocktown Owl statue, Meeting the happy mask salesman, and Skullkid's backstory.

Rando players will now start with:
Ocarina
Three activated owl statues: Clocktown, Southern Swamp and Milk Road
Song of time and Soaring
Start as Human with kokiri sword and hylian shield

More itemized changes:
- romfs uncommented in Makefile for direct play testing.
- 4 cut scene flags were broken out of the gap arrays into their own variables.
- Bit field created for most of the event flags.
- Bit field found during cutscene skip development but it's purpose is still unclear.
- Setting flags for cutecene skipping is in its own function.
- FastElegyStatues was re enabled.
- some debug code was left in, may be helpful for other devs.
