### PR TITLE
Flag Decomp Progress Update 2

### DIFF
--- a/code/include/game/common_data.h
+++ b/code/include/game/common_data.h
@@ -231,7 +231,7 @@ namespace game {
     char anonymous_12;
     char anonymous_13;
     u8 boss_started_flags;
-    char more_boss_start_flags;
+    u8 more_boss_start_flags;
     char anonymous_16;
     char gap33[205];
     char anonymous_a[24];  // Possible permanent scene flags? Could be put in the gap to match 0x1C
@@ -293,8 +293,8 @@ namespace game {
     int anonymous_57;
     int anonymous_58;
     u8 gap11EC[4];
-    u8 overworld_map_data_0x11F0[16];
-    u8 gap1200[16];
+    u8 overworld_map_data[15];
+    u8 gap11FF[17];
     union SkulltulaRegister {
       u32 raw;
 
@@ -304,9 +304,9 @@ namespace game {
     SkulltulaRegister skulltulas_collected;
     int anonymous_60;
     u8 gap1218[4];
-    int defeated_bosses_stack;  // or seen giants flag stack
-    u8 last_defeated_boss;  // or last viewed giant cutscene, values 4 and greater makes woodfall
-                            // giant repeat for all temples.
+    u8 defeated_bosses[4];      // like a history log of deafeated bosses or seen giants
+    u8 previous_defeated_boss;  // or last viewed giant cutscene, values 4 and greater makes
+                                // woodfall giant repeat for all temples.
     u8 gap1221[3];
     int anonymous_63;
     u8 gap1228[8];
@@ -499,7 +499,7 @@ namespace game {
     };
     CutSceneFlags cut_scene_flag_bundle;
     char anonymous_153;
-    char dungeon_skip_portal_cutscene_0x3C_to_skip_all;
+    u8 dungeon_skip_portal_cutscene_0x3C_to_skip_all;
     char anonymous_155;
     char anonymous_156;
     char anonymous_157;
@@ -523,14 +523,16 @@ namespace game {
     int anonymous_162;
     u8 gap12F8;
     char activate_scarecrow_song_0x01;
-    u8 scarecrow_song_data_12FA[128];  // default song is LLLLLLLL
+    u8 scarecrow_song_data[128];  // default song is LLLLLLLL
     char anonymous_164;
     char anonymous_165;
     char anonymous_166;
     char anonymous_167;
     char anonymous_168;
     char anonymous_169;
-    u8 winning_lottery_numbers[9];  // day 1 is 0-2, day 2 is 3-5 ect.
+    u8 winning_lottery_numbers_day_1[3];
+    u8 winning_lottery_numbers_day_2[3];
+    u8 winning_lottery_numbers_day_3[3];
     char anonymous_179;
     u8 gap138A[5];
     u8 bomberscode[5];
@@ -551,7 +553,7 @@ namespace game {
     u16 anonymous_198;
     u8 gap_14E8[136];
     u32 field_1570;
-    u8 gap_1574[1020];  // likely to have bomber's notebook data
+    u8 gap_1574[1020];
     u32 field_1970;
     u8 gap_1974[176];
     char anonymous_199;

--- a/code/include/game/common_data.h
+++ b/code/include/game/common_data.h
@@ -164,7 +164,7 @@ namespace game {
       BitField<14, 1, u32> eponas_song;
       BitField<15, 1, u32> song_of_soaring;
       BitField<16, 1, u32> song_of_storms;
-      BitField<17, 1, u32> suns_song;
+      BitField<17, 1, u32> scarecrows_song_icon;
       BitField<18, 1, u32> bombers_notebook;
       BitField<19, 5, u32> pad_2;
       BitField<24, 1, u32> lullaby_intro;
@@ -231,7 +231,7 @@ namespace game {
     char anonymous_12;
     char anonymous_13;
     u8 boss_started_flags;
-    char anonymous_15;
+    char more_boss_start_flags;
     char anonymous_16;
     char gap33[205];
     char anonymous_a[24];  // Possible permanent scene flags? Could be put in the gap to match 0x1C
@@ -292,7 +292,9 @@ namespace game {
     int anonymous_56;
     int anonymous_57;
     int anonymous_58;
-    u8 gap11EC[36];
+    u8 gap11EC[4];
+    u8 overworld_map_data_0x11F0[16];
+    u8 gap1200[16];
     union SkulltulaRegister {
       u32 raw;
 
@@ -302,15 +304,19 @@ namespace game {
     SkulltulaRegister skulltulas_collected;
     int anonymous_60;
     u8 gap1218[4];
-    int anonymous_61;  // XXX: Possible scene flags.
-    int anonymous_62;  // XXX: Possible scene flags.
+    int defeated_bosses_stack;  // or seen giants flag stack
+    u8 last_defeated_boss;  // or last viewed giant cutscene, values 4 and greater makes woodfall
+                            // giant repeat for all temples.
+    u8 gap1221[3];
     int anonymous_63;
     u8 gap1228[8];
-    int anonymous_64;
+    u16 bank_rupee_count;
+    u16 anonymous_64;
     u8 gap1234[8];
     int anonymous_65;
     int anonymous_66;
-    int anonymous_67;
+    u16 player_guessed_lottery_numbers;
+    u16 anonymous_67;
     int anonymous_68;
     u8 gap124C[4];
     union CameraPanningEventFlags {
@@ -353,7 +359,7 @@ namespace game {
     char tatl_apology_dialogue_post_Odolwa_0x80;
     char anonymous_72;
     char anonymous_73;
-    char anonymous_74;
+    char skip_tingle_intro_dialogue_0x01;
     char anonymous_75;
     u8 ct_guard_allows_through_if_0x20;
     char anonymous_77;
@@ -396,7 +402,7 @@ namespace game {
     char anonymous_95;
     char anonymous_96;
     char anonymous_97;
-    char anonymous_98;
+    char overworld_map_get_flags_0x3F_for_all;
     char anonymous_99;
     char anonymous_100_0x10_if_rock_sirloin_spawned;
     char anonymous_101;
@@ -421,7 +427,7 @@ namespace game {
     char anonymous_111;
     char anonymous_112;
     char anonymous_113;
-    char skip_tatl_talking_0x04;
+    char skip_tatl_talking_0x04;  // also has bank reward flags
     char anonymous_115;
     char swamp_deku_removed_if_0x10;  // Don Gero Flag Maybe
     char anonymous_117;
@@ -443,7 +449,7 @@ namespace game {
     char anonymous_124;
     char anonymous_125;
     char anonymous_126;
-    char anonymous_127;
+    char removes_scarecrow_from_shop_0x08;
     char anonymous_128;  // Possibly more Cutscene flags
     char anonymous_129;
     char anonymous_130;
@@ -462,10 +468,10 @@ namespace game {
       BitField<7, 1, u8> go_to_skullkid;
     };
     TatlDialogueFlags tatl_dialogue_flags1;
-    char anonymous_136;
+    char mikau_pushed_to_shore_0x10;
     char anonymous_137;
     char anonymous_138;
-    char anonymous_139;
+    char mikau_dialogue_flags_0x03;
     char anonymous_140;
     char anonymous_141;
     u8 gap12AE[6];
@@ -480,18 +486,20 @@ namespace game {
     char anonymous_148[6];
     char anonymous_149;
     char anonymous_150;
-    char anonymous_151;
+    char activate_dungeon_skip_portal_0xF0_for_all;
     union CutSceneFlags {
       u8 raw;
 
       BitField<0, 1, u8> owl_statue_cut_scene;
-      BitField<1, 3, u8> unknown1;
+      BitField<1, 2, u8> unknown1;
+      BitField<3, 1, u8> map_tutorial_by_tingle;
       BitField<4, 2, u8> deku_palace_throne_room_camera_pan;
-      BitField<5, 3, u8> unknown2;
+      BitField<5, 1, u8> tatl_moon_tear_dialogue;
+      BitField<6, 2, u8> unknown2;
     };
     CutSceneFlags cut_scene_flag_bundle;
     char anonymous_153;
-    char anonymous_154;
+    char dungeon_skip_portal_cutscene_0x3C_to_skip_all;
     char anonymous_155;
     char anonymous_156;
     char anonymous_157;
@@ -514,30 +522,18 @@ namespace game {
     int unknown_flags_0x12F0;
     int anonymous_162;
     u8 gap12F8;
-    char anonymous_163;
-    u8 gap12FA[128];
+    char activate_scarecrow_song_0x01;
+    u8 scarecrow_song_data_12FA[128];  // default song is LLLLLLLL
     char anonymous_164;
     char anonymous_165;
     char anonymous_166;
     char anonymous_167;
     char anonymous_168;
     char anonymous_169;
-    char anonymous_170;
-    char anonymous_171;
-    char anonymous_172;
-    char anonymous_173;
-    char anonymous_174;
-    char anonymous_175;
-    char anonymous_176;
-    char anonymous_177;
-    char anonymous_178;
+    u8 winning_lottery_numbers[9];  // day 1 is 0-2, day 2 is 3-5 ect.
     char anonymous_179;
     u8 gap138A[5];
-    char bombercode_first_digit;
-    char bombercode_second_digit;
-    char bombercode_third_digit;
-    char bombercode_fourth_digit;
-    char bombercode_fifth_digit;
+    u8 bomberscode[5];
     char anonymous_185;
     char anonymous_186[3];
     u16 anonymous_187;
@@ -555,37 +551,14 @@ namespace game {
     u16 anonymous_198;
     u8 gap_14E8[136];
     u32 field_1570;
-    u8 gap_1574[1020];
+    u8 gap_1574[1020];  // likely to have bomber's notebook data
     u32 field_1970;
     u8 gap_1974[176];
     char anonymous_199;
     char anonymous_200;
     u16 anonymous_201;
-    u8 gap1A30[20];  // Items?
-    char anonymous_202;
-    char anonymous_203;
-    char anonymous_204;
-    char anonymous_205;
-    char anonymous_206;
-    char anonymous_207;
-    char anonymous_208;
-    char anonymous_209;
-    char anonymous_210;
-    char anonymous_211;
-    char anonymous_212;
-    char anonymous_213;
-    char anonymous_214;
-    char anonymous_215;
-    char anonymous_216;
-    char anonymous_217;
-    char anonymous_218;
-    char anonymous_219;
-    char anonymous_220;
-    char anonymous_221;
-    char anonymous_222;
-    char anonymous_223;
-    char anonymous_224;
-    char anonymous_225;
+    u8 order_of_equip_items_in_inventory[20];
+    u8 order_of_masks_in_inventory[24];
     u8 gap1A5C[8];
     u16 anonymous_226;
     char anonymous_227[2];

--- a/code/include/game/common_data.h
+++ b/code/include/game/common_data.h
@@ -359,7 +359,7 @@ namespace game {
     char tatl_apology_dialogue_post_Odolwa_0x80;
     char anonymous_72;
     char anonymous_73;
-    char skip_tingle_intro_dialogue_0x01;
+    u8 skip_tingle_intro_dialogue_0x01;
     char anonymous_75;
     u8 ct_guard_allows_through_if_0x20;
     char anonymous_77;
@@ -369,7 +369,7 @@ namespace game {
     u8 ct_deku_removed_if_c0;
     char anonymous_81;
     char anonymous_82;
-    char open_woodfall_temple_if_0x01;
+    u8 open_woodfall_temple_if_0x01;
     char anonymous_84;
     char anonymous_85;
     u8 has_great_spin_0x02;
@@ -402,9 +402,9 @@ namespace game {
     char anonymous_95;
     char anonymous_96;
     char anonymous_97;
-    char overworld_map_get_flags_0x3F_for_all;
+    u8 overworld_map_get_flags_0x3F_for_all;
     char anonymous_99;
-    char anonymous_100_0x10_if_rock_sirloin_spawned;
+    u8 anonymous_100_0x10_if_rock_sirloin_spawned;
     char anonymous_101;
     char anonymous_102;
     char anonymous_103;
@@ -427,9 +427,9 @@ namespace game {
     char anonymous_111;
     char anonymous_112;
     char anonymous_113;
-    char skip_tatl_talking_0x04;  // also has bank reward flags
+    u8 skip_tatl_talking_0x04;  // also has bank reward flags
     char anonymous_115;
-    char swamp_deku_removed_if_0x10;  // Don Gero Flag Maybe
+    u8 swamp_deku_removed_if_0x10;  // Don Gero Flag Maybe
     char anonymous_117;
     char anonymous_118;
     char anonymous_119;
@@ -449,7 +449,7 @@ namespace game {
     char anonymous_124;
     char anonymous_125;
     char anonymous_126;
-    char removes_scarecrow_from_shop_0x08;
+    u8 removes_scarecrow_from_shop_0x08;
     char anonymous_128;  // Possibly more Cutscene flags
     char anonymous_129;
     char anonymous_130;
@@ -468,10 +468,10 @@ namespace game {
       BitField<7, 1, u8> go_to_skullkid;
     };
     TatlDialogueFlags tatl_dialogue_flags1;
-    char mikau_pushed_to_shore_0x10;
+    u8 mikau_pushed_to_shore_0x10;
     char anonymous_137;
     char anonymous_138;
-    char mikau_dialogue_flags_0x03;
+    u8 mikau_dialogue_flags_0x03;
     char anonymous_140;
     char anonymous_141;
     u8 gap12AE[6];
@@ -486,7 +486,7 @@ namespace game {
     char anonymous_148[6];
     char anonymous_149;
     char anonymous_150;
-    char activate_dungeon_skip_portal_0xF0_for_all;
+    u8 activate_dungeon_skip_portal_0xF0_for_all;
     union CutSceneFlags {
       u8 raw;
 
@@ -522,7 +522,7 @@ namespace game {
     int unknown_flags_0x12F0;
     int anonymous_162;
     u8 gap12F8;
-    char activate_scarecrow_song_0x01;
+    u8 activate_scarecrow_song_0x01;
     u8 scarecrow_song_data[128];  // default song is LLLLLLLL
     char anonymous_164;
     char anonymous_165;
@@ -547,7 +547,7 @@ namespace game {
     char num_ftickets_rank10;
     char anonymous_193;
     char anonymous_194;
-    char used_instruments;
+    u8 used_instruments;
     char anonymous_196;
     char anonymous_197;
     u16 anonymous_198;

--- a/code/include/rnd/savefile.h
+++ b/code/include/rnd/savefile.h
@@ -6,9 +6,10 @@
 
 namespace rnd {
   void SaveFile_SkipMinorCutscenes();
-  void SaveFile_SetStartingOwlStatues();
   void SaveFile_SetFastAnimationFlags();
+  void SaveFile_SetStartingOwlStatues();
   void SaveFile_SetComfortOptions();
+  void SaveFile_FillOverWorldMapData();
   u8 SaveFile_GetMedallionCount(void);
   u8 SaveFile_GetStoneCount(void);
   u8 SaveFile_GetDungeonCount(void);

--- a/code/include/rnd/settings.h
+++ b/code/include/rnd/settings.h
@@ -260,8 +260,8 @@ namespace rnd {
 
     u8 freeScarecrow;
 
-    u8 preApprovedBeans;
-    u8 preApprovedPowerKeg;
+    u8 skipBeansTest;
+    u8 skipPowerKegTest;
 
     u8 damageMultiplier;
     u8 gossipStoneHints;

--- a/code/include/rnd/settings.h
+++ b/code/include/rnd/settings.h
@@ -258,6 +258,11 @@ namespace rnd {
     u8 skipMinigamePhases;
     u8 skipBombersMinigame;
 
+    u8 freeScarecrow;
+
+    u8 preApprovedBeans;
+    u8 preApprovedPowerKeg;
+
     u8 damageMultiplier;
     u8 gossipStoneHints;
     u8 chestAnimations;

--- a/code/source/rnd/savefile.cpp
+++ b/code/source/rnd/savefile.cpp
@@ -24,6 +24,7 @@ namespace rnd {
     saveData.inventory.inventory_count_register.wallet_upgrade = 2;
     saveData.inventory.inventory_count_register.stick_upgrades = 2;
     saveData.inventory.inventory_count_register.nut_upgrade = 2;
+    saveData.player.rupee_count = 500;
     saveData.inventory.items[0] = game::ItemId::Ocarina;
     saveData.inventory.items[1] = game::ItemId::Arrow;
     saveData.inventory.items[2] = game::ItemId::FireArrow;
@@ -31,19 +32,21 @@ namespace rnd {
     saveData.inventory.items[4] = game::ItemId::LightArrow;
     saveData.inventory.items[6] = game::ItemId::Bomb;
     saveData.inventory.items[7] = game::ItemId::Bombchu;
+    saveData.inventory.items[8] = game::ItemId::DekuStick;
     saveData.inventory.items[9] = game::ItemId::DekuNuts;
-    saveData.inventory.items[10] = game::ItemId::DekuStick;
+    saveData.inventory.items[10] = game::ItemId::MagicBean;
+    saveData.inventory.items[12] = game::ItemId::PowderKeg;
     saveData.inventory.items[13] = game::ItemId::PictographBox;
+    saveData.inventory.items[14] = game::ItemId::LensOfTruth;
     saveData.inventory.items[15] = game::ItemId::Hookshot;
-    saveData.inventory.items[16] = game::ItemId::PowderKeg;
 
-    saveData.inventory.masks[0] = game::ItemId::DekuMask;
-    saveData.inventory.masks[1] = game::ItemId::GoronMask;
-    saveData.inventory.masks[2] = game::ItemId::ZoraMask;
-    saveData.inventory.masks[3] = game::ItemId::FierceDeityMask;
-    saveData.inventory.masks[4] = game::ItemId::GibdoMask;
-    saveData.inventory.masks[5] = game::ItemId::BunnyHood;
-    saveData.inventory.masks[6] = game::ItemId::GaroMask;
+    saveData.inventory.masks[5] = game::ItemId::DekuMask;
+    saveData.inventory.masks[11] = game::ItemId::GoronMask;
+    saveData.inventory.masks[17] = game::ItemId::ZoraMask;
+    saveData.inventory.masks[23] = game::ItemId::FierceDeityMask;
+    // saveData.inventory.masks[4] = game::ItemId::GibdoMask;
+    saveData.inventory.masks[8] = game::ItemId::BunnyHood;
+    // saveData.inventory.masks[6] = game::ItemId::GaroMask;
 
     saveData.inventory.woodfall_temple_keys = 8;
     saveData.inventory.snowhead_temple_keys = 8;
@@ -62,15 +65,16 @@ namespace rnd {
     saveData.inventory.stone_tower_dungeon_items.compass = 1;
     saveData.inventory.stone_tower_dungeon_items.boss_key = 1;
     saveData.player.magic_acquired = 1;  // Game does not check if value = 0, magic items still work
-    saveData.player.magic_size_type = 2;  // not init until saved?
+    saveData.player.magic_size_type = 2;
     saveData.player.magic = 96;
     saveData.player.magic_num_upgrades = 1;
+    saveData.flag_8_for_no_magic_use = 0x08;  // enable for inf magic
     saveData.equipment.data[3].item_btns[0] = game::ItemId::DekuNuts;
     saveData.inventory.item_counts[6] = 50;   // Arrows
     saveData.inventory.item_counts[11] = 40;  // Bombs
     saveData.inventory.item_counts[12] = 40;  // Bombchus
     saveData.inventory.item_counts[14] = 30;  // Nuts
-    saveData.inventory.item_counts[13] = 10;  // Sticks
+    saveData.inventory.item_counts[13] = 20;  // Sticks
     saveData.has_great_spin_0x02 = 2;         // Set great spin.
 
     saveData.player.owl_statue_flags.great_bay = 1;
@@ -91,8 +95,15 @@ namespace rnd {
     saveData.inventory.collect_register.eponas_song = 1;
     saveData.inventory.collect_register.song_of_soaring = 1;
     saveData.inventory.collect_register.song_of_time = 1;
+    // saveData.inventory.collect_register.oath_to_order = 1;
+    // saveData.inventory.collect_register.song_of_healing = 1;
 
     gSettingsContext.skipBombersMinigame = 1;
+    gSettingsContext.freeScarecrow = 1;
+    saveData.activate_dungeon_skip_portal_0xF0_for_all = 0xF0;
+
+    SaveFile_FillOverWorldMapData();
+
 #endif
     // TODO: Decomp event flags. Most likely in the large anonymous structs in the SaveData.
     u8 isNewFile = saveData.has_completed_intro;
@@ -118,11 +129,12 @@ namespace rnd {
 
       SaveFile_SetStartingInventory();
 
-      // These events replay after song of time aka temp flags
+      // These events replay after song of time
       saveData.ct_guard_allows_through_if_0x20 = 0x20;
       saveData.tatl_dialogue_snowhead_entry_0x08 = 0x08;
       saveData.pirate_leader_dialogue_0x20 = 0x20;
       saveData.temp_event_flag_bundle1.ct_deku_in_flower_if_present = 1;
+      saveData.skip_tingle_intro_dialogue_0x01 = 0x01;
 
       saveData.player_form = game::act::Player::Form::Human;
       game::GiveItem(game::ItemId::BombersNotebook);
@@ -166,6 +178,7 @@ namespace rnd {
     saveData.ikana_castle_camera_pan_0x08 = 0x80;
 
     // Tatl constant tatling skip
+    saveData.cut_scene_flag_bundle.tatl_moon_tear_dialogue = 1;
     saveData.tatl_dialogue_flags2.go_south = 1;
     saveData.tatl_dialogue_flags1.go_north = 1;
     saveData.tatl_dialogue_flags1.go_west = 1;
@@ -177,16 +190,33 @@ namespace rnd {
     saveData.talt_dialogue_great_bay_temple.waterwheel_room_tatl_dialogue = 1;
     saveData.talt_dialogue_great_bay_temple.whirlpool_room_tatl_dialogue = 1;
 
+    // tutorials
+    saveData.cut_scene_flag_bundle.map_tutorial_by_tingle = 1;
+
     // Misc cutscenes
     saveData.meeting_happy_mask_salesman_0x01 = 0x01;
     saveData.skullkid_backstory_cutscene_0x10 = 0x10;
     saveData.cut_scene_flag_bundle.owl_statue_cut_scene = 1;
+    saveData.dungeon_skip_portal_cutscene_0x3C_to_skip_all = 0x3C;
     saveData.event_flag_bundle.skip_swimming_to_great_bay_temple_cutscene = 1;
 
     // Needs to be greater than zero to skip first time song of time cutscene
     saveData.player.song_of_time_counter = 1;
   }
-
+  void SaveFile_SetFastAnimationFlags() {
+    game::SaveData& saveData = game::GetCommonData().save;
+    // Masks
+    saveData.set_fast_mask_animations.has_worn_deku_mask_once = 1;
+    saveData.set_fast_mask_animations.has_worn_goron_mask_once = 1;
+    saveData.set_fast_mask_animations.has_worn_zora_mask_once = 1;
+    saveData.set_fast_mask_animations.has_worn_deity_mask_once = 1;
+    // Dungeons
+    saveData.set_fast_animation_flags.woodfall_temple_opened_at_least_once = 1;
+    saveData.set_fast_animation_flags.snowhead_temple_opened_at_least_once = 1;
+    saveData.set_fast_animation_flags.greatbay_temple_opened_at_least_once = 1;
+    // Misc
+    saveData.set_fast_animation_flags.deku_flown_in_at_least_once = 1;
+  }
   void SaveFile_SetStartingOwlStatues() {
     game::SaveData& saveData = game::GetCommonData().save;
     // Walkable statues, could have an option to bundle this subgroup
@@ -212,32 +242,56 @@ namespace rnd {
     if (gSettingsContext.startingOwlStatues.stone_tower)
       saveData.player.owl_statue_flags.stone_tower = 1;
   }
-  void SaveFile_SetFastAnimationFlags() {
-    game::SaveData& saveData = game::GetCommonData().save;
-    // Masks
-    saveData.set_fast_mask_animations.has_worn_deku_mask_once = 1;
-    saveData.set_fast_mask_animations.has_worn_goron_mask_once = 1;
-    saveData.set_fast_mask_animations.has_worn_zora_mask_once = 1;
-    saveData.set_fast_mask_animations.has_worn_deity_mask_once = 1;
-    // Dungeons
-    saveData.set_fast_animation_flags.woodfall_temple_opened_at_least_once = 1;
-    saveData.set_fast_animation_flags.snowhead_temple_opened_at_least_once = 1;
-    saveData.set_fast_animation_flags.greatbay_temple_opened_at_least_once = 1;
-    // Misc
-    saveData.set_fast_animation_flags.deku_flown_in_at_least_once = 1;
-  }
   void SaveFile_SetComfortOptions() {
     game::SaveData& saveData = game::GetCommonData().save;
     if (gSettingsContext.skipBombersMinigame) {
       // Not sure if bombers code is used elsewhere in the game's code
-      saveData.bombercode_first_digit = 0x01;
-      saveData.bombercode_second_digit = 0x01;
-      saveData.bombercode_third_digit = 0x01;
-      saveData.bombercode_fourth_digit = 0x01;
-      saveData.bombercode_fifth_digit = 0x01;
+      saveData.bomberscode[0] = 0x01;
+      saveData.bomberscode[1] = 0x01;
+      saveData.bomberscode[2] = 0x01;
+      saveData.bomberscode[3] = 0x01;
+      saveData.bomberscode[4] = 0x01;
       saveData.temp_event_flag_bundle1.bomber_open_hideout =
           1;  // Currently gets reset by Song of time
     }
+    // Game uses an inventory check to determine whether you can
+    // buy beans or powder kegs
+    if (gSettingsContext.preApprovedBeans) {
+      saveData.inventory.items[10] = game::ItemId::MagicBean;
+    }
+    if (gSettingsContext.preApprovedPowerKeg) {
+      saveData.inventory.items[12] = game::ItemId::PowderKeg;
+    }
+
+    if (gSettingsContext.freeScarecrow) {
+      // Currently sets song to the ingame default: LLLLLLLL
+      saveData.inventory.collect_register.scarecrows_song_icon = 1;
+      // both flags below get reset to 0 by song of time
+      saveData.removes_scarecrow_from_shop_0x08 = 0x08;
+      saveData.activate_scarecrow_song_0x01 = 0x01;
+    }
+  }
+  void SaveFile_FillOverWorldMapData() {
+    game::SaveData& saveData = game::GetCommonData().save;
+    saveData.overworld_map_get_flags_0x3F_for_all = 0x3F;
+    // setting individual maps is possible if necessary, the game just ||'s the map data in.
+    // Currently sets data for all maps
+    saveData.overworld_map_data_0x11F0[0] = 0x01;
+    saveData.overworld_map_data_0x11F0[1] = 0x34;
+    saveData.overworld_map_data_0x11F0[2] = 0xBF;
+    saveData.overworld_map_data_0x11F0[3] = 0x72;
+    saveData.overworld_map_data_0x11F0[4] = 0xBD;
+    saveData.overworld_map_data_0x11F0[5] = 0xFB;
+    saveData.overworld_map_data_0x11F0[6] = 0xBD;
+    saveData.overworld_map_data_0x11F0[7] = 0x7B;
+    saveData.overworld_map_data_0x11F0[8] = 0x6F;
+    saveData.overworld_map_data_0x11F0[9] = 0xFD;
+    saveData.overworld_map_data_0x11F0[10] = 0xFF;
+    saveData.overworld_map_data_0x11F0[11] = 0x7F;
+    saveData.overworld_map_data_0x11F0[12] = 0x0B;
+    saveData.overworld_map_data_0x11F0[13] = 0xFD;
+    saveData.overworld_map_data_0x11F0[14] = 0x07;
+    // saveData.overworld_map_data_0x11F0[15] = 0x00;
   }
   // Resolve the item ID for the starting bottle
   static void SaveFile_GiveStartingBottle(StartingBottleSetting startingBottle, u8 bottleSlot) {
@@ -266,7 +320,7 @@ namespace rnd {
     game::SaveData& saveData = game::GetCommonData().save;
     // give maps and compasses
     if (gSettingsContext.mapsAndCompasses ==
-        (u8)MapsAndCompassesSetting::MAPSANDCOMPASSES_START_WITH) {
+        (u8)MapsAndCompassesSetting::MAPSANDCOMPASSES_ANY_DUNGEON) {
       inventoryData.woodfall_dungeon_items.map = 1;
       inventoryData.woodfall_dungeon_items.compass = 1;
       inventoryData.snowhead_dungeon_items.map = 1;
@@ -275,6 +329,10 @@ namespace rnd {
       inventoryData.great_bay_dungeon_items.compass = 1;
       inventoryData.stone_tower_dungeon_items.map = 1;
       inventoryData.stone_tower_dungeon_items.compass = 1;
+    }
+    if (gSettingsContext.mapsAndCompasses ==
+        (u8)MapsAndCompassesSetting::MAPSANDCOMPASSES_OVERWORLD) {
+      SaveFile_FillOverWorldMapData();
     }
 
     // give small keys

--- a/code/source/rnd/savefile.cpp
+++ b/code/source/rnd/savefile.cpp
@@ -257,14 +257,14 @@ namespace rnd {
     // Game uses an inventory check to determine whether you can
     // buy beans or powder kegs
     if (gSettingsContext.skipBeansTest) {
-      // currently disables the free bean check
+      // currently this will disable the free bean check
       // Instead bean daddy sells one bean for 10 rupees
-      saveData.inventory.items[10] = game::ItemId::MagicBean;
+      // saveData.inventory.items[10] = game::ItemId::MagicBean;
     }
     if (gSettingsContext.skipPowerKegTest) {
-      // currently disables the PowerKegTest item check
+      // currently this will disable the PowerKegTest item check
       // Instead big goron sells one powder keg for 20 rupees
-      saveData.inventory.items[12] = game::ItemId::PowderKeg;
+      // saveData.inventory.items[12] = game::ItemId::PowderKeg;
     }
 
     if (gSettingsContext.freeScarecrow) {

--- a/code/source/rnd/savefile.cpp
+++ b/code/source/rnd/savefile.cpp
@@ -258,12 +258,12 @@ namespace rnd {
     // buy beans or powder kegs
     if (gSettingsContext.skipBeansTest) {
       // currently disables the free bean check
-      // Instead big goron sells one powder keg for 20 rupees
+      // Instead bean daddy sells one bean for 10 rupees
       saveData.inventory.items[10] = game::ItemId::MagicBean;
     }
     if (gSettingsContext.skipPowerKegTest) {
       // currently disables the PowerKegTest item check
-      // Instead bean daddy sells one bean for 10 rupees
+      // Instead big goron sells one powder keg for 20 rupees
       saveData.inventory.items[12] = game::ItemId::PowderKeg;
     }
 

--- a/code/source/rnd/savefile.cpp
+++ b/code/source/rnd/savefile.cpp
@@ -44,9 +44,9 @@ namespace rnd {
     saveData.inventory.masks[11] = game::ItemId::GoronMask;
     saveData.inventory.masks[17] = game::ItemId::ZoraMask;
     saveData.inventory.masks[23] = game::ItemId::FierceDeityMask;
-    // saveData.inventory.masks[4] = game::ItemId::GibdoMask;
+    saveData.inventory.masks[19] = game::ItemId::GibdoMask;
     saveData.inventory.masks[8] = game::ItemId::BunnyHood;
-    // saveData.inventory.masks[6] = game::ItemId::GaroMask;
+    saveData.inventory.masks[20] = game::ItemId::GaroMask;
 
     saveData.inventory.woodfall_temple_keys = 8;
     saveData.inventory.snowhead_temple_keys = 8;
@@ -68,7 +68,7 @@ namespace rnd {
     saveData.player.magic_size_type = 2;
     saveData.player.magic = 96;
     saveData.player.magic_num_upgrades = 1;
-    saveData.flag_8_for_no_magic_use = 0x08;  // enable for inf magic
+    // saveData.flag_8_for_no_magic_use = 0x08;  // enable for inf magic
     saveData.equipment.data[3].item_btns[0] = game::ItemId::DekuNuts;
     saveData.inventory.item_counts[6] = 50;   // Arrows
     saveData.inventory.item_counts[11] = 40;  // Bombs
@@ -256,10 +256,14 @@ namespace rnd {
     }
     // Game uses an inventory check to determine whether you can
     // buy beans or powder kegs
-    if (gSettingsContext.preApprovedBeans) {
+    if (gSettingsContext.skipBeansTest) {
+      // currently disables the free bean check
+      // Instead big goron sells one powder keg for 20 rupees
       saveData.inventory.items[10] = game::ItemId::MagicBean;
     }
-    if (gSettingsContext.preApprovedPowerKeg) {
+    if (gSettingsContext.skipPowerKegTest) {
+      // currently disables the PowerKegTest item check
+      // Instead bean daddy sells one bean for 10 rupees
       saveData.inventory.items[12] = game::ItemId::PowderKeg;
     }
 
@@ -276,22 +280,21 @@ namespace rnd {
     saveData.overworld_map_get_flags_0x3F_for_all = 0x3F;
     // setting individual maps is possible if necessary, the game just ||'s the map data in.
     // Currently sets data for all maps
-    saveData.overworld_map_data_0x11F0[0] = 0x01;
-    saveData.overworld_map_data_0x11F0[1] = 0x34;
-    saveData.overworld_map_data_0x11F0[2] = 0xBF;
-    saveData.overworld_map_data_0x11F0[3] = 0x72;
-    saveData.overworld_map_data_0x11F0[4] = 0xBD;
-    saveData.overworld_map_data_0x11F0[5] = 0xFB;
-    saveData.overworld_map_data_0x11F0[6] = 0xBD;
-    saveData.overworld_map_data_0x11F0[7] = 0x7B;
-    saveData.overworld_map_data_0x11F0[8] = 0x6F;
-    saveData.overworld_map_data_0x11F0[9] = 0xFD;
-    saveData.overworld_map_data_0x11F0[10] = 0xFF;
-    saveData.overworld_map_data_0x11F0[11] = 0x7F;
-    saveData.overworld_map_data_0x11F0[12] = 0x0B;
-    saveData.overworld_map_data_0x11F0[13] = 0xFD;
-    saveData.overworld_map_data_0x11F0[14] = 0x07;
-    // saveData.overworld_map_data_0x11F0[15] = 0x00;
+    saveData.overworld_map_data[0] = 0x01;
+    saveData.overworld_map_data[1] = 0x34;
+    saveData.overworld_map_data[2] = 0xBF;
+    saveData.overworld_map_data[3] = 0x72;
+    saveData.overworld_map_data[4] = 0xBD;
+    saveData.overworld_map_data[5] = 0xFB;
+    saveData.overworld_map_data[6] = 0xBD;
+    saveData.overworld_map_data[7] = 0x7B;
+    saveData.overworld_map_data[8] = 0x6F;
+    saveData.overworld_map_data[9] = 0xFD;
+    saveData.overworld_map_data[10] = 0xFF;
+    saveData.overworld_map_data[11] = 0x7F;
+    saveData.overworld_map_data[12] = 0x0B;
+    saveData.overworld_map_data[13] = 0xFD;
+    saveData.overworld_map_data[14] = 0x07;
   }
   // Resolve the item ID for the starting bottle
   static void SaveFile_GiveStartingBottle(StartingBottleSetting startingBottle, u8 bottleSlot) {


### PR DESCRIPTION
Somewhere along the way the bit for sun song in collect register ended up being the bit for scarecrow's song, it no longer gives player the ability to play sun song in game.

Thinking some more on my bitfields, they can be compressed back to u8's or u32's in exchange of losing information on what each bit does individually, though information can be stored elsewhere too.

Added free scarecrow option, it works but is primitive since I'm currently limited to event flags rn.
The two other options, preapproved beans and powder keg, currently start player with zero of the those items as the items themselves ended up being the flag used in those scenarios.

SaveFile_SetFastAnimationFlags() got moved to above SaveFile_SetStartingOwlStatues()

Start with all overworld maps has been implemented.