### PR TITLE
Fix all get item issues with resolving upgrades.

### DIFF
--- a/code/include/rnd/item_effect.h
+++ b/code/include/rnd/item_effect.h
@@ -20,6 +20,7 @@ namespace rnd {
   void ItemEffect_GiveMagic(game::CommonData* comData, s16 arg1, s16 arg2);
   void ItemEffect_GiveSkulltula(game::CommonData* comData, s16 arg1, s16 arg2);
   void ItemEffect_GiveDoubleMagic(game::CommonData* comData, s16 arg1, s16 arg2);
+  void ItemEffect_GiveProgressiveMagic(game::CommonData* comData, s16 arg1, s16 arg2);
   void ItemEffect_GiveGreatSpin(game::CommonData* comData, s16 arg1, s16 arg2);
   void ItemEffect_GiveDoubleDefense(game::CommonData* comData, s16 arg1, s16 arg2);
   void ItemEffect_GiveOcarina(game::CommonData* comData, s16 arg1, s16 arg2);

--- a/code/include/rnd/item_upgrade.h
+++ b/code/include/rnd/item_upgrade.h
@@ -9,6 +9,8 @@ namespace rnd {
   GetItemID ItemUpgrade_Quiver(game::SaveData*, GetItemID);
   GetItemID ItemUpgrade_Wallet(game::SaveData*, GetItemID);
   GetItemID ItemUpgrade_Magic(game::SaveData*, GetItemID);
+  GetItemID ItemUpgrade_LargeMagic(game::SaveData*, GetItemID);
+  GetItemID ItemUpgrade_SmallMagic(game::SaveData*, GetItemID);
   GetItemID ItemUpgrade_Sword(game::SaveData*, GetItemID);
   GetItemID ItemUpgrade_ArrowsToRupee(game::SaveData*, GetItemID);
   GetItemID ItemUpgrade_BombsToRupee(game::SaveData*, GetItemID);

--- a/code/source/asm/hooks.s
+++ b/code/source/asm/hooks.s
@@ -130,9 +130,11 @@ noOverrideBomberTextID:
 
 .global hook_OverrideItemID 
 hook_OverrideItemID:
+    push {r1}
     ldr r1,.rActiveItemRow_addr
     ldr r1,[r1]
     cmp r1,#0x0
+    pop {r1}
     beq noOverrideItemID
     push {r0-r12, lr}
     bl ItemOverride_GetItemTextAndItemID

--- a/code/source/rnd/item_effect.cpp
+++ b/code/source/rnd/item_effect.cpp
@@ -109,8 +109,27 @@ namespace rnd {
     // assign them.
     if (comData->save.equipment.data[3].item_btns[0] != game::ItemId::DekuNuts)
       comData->save.equipment.data[3].item_btns[0] = game::ItemId::DekuNuts;
-    comData->magic_accumulator = 0x60;  // Fill meter
-    return;
+    comData->save.player.magic = 0x60;  // Fill meter
+  }
+
+  void ItemEffect_GiveMagic(game::CommonData* comData, s16 arg1, s16 arg2) {
+    comData->save.player.magic_acquired = 1;
+    comData->save.player.magic_size_type = 0;
+    comData->save.player.magic = 0x30;
+    if (comData->save.equipment.data[3].item_btns[0] != game::ItemId::DekuNuts)
+      comData->save.equipment.data[3].item_btns[0] = game::ItemId::DekuNuts;
+    comData->save.player.magic_num_upgrades = 0;  // Single Magic
+  }
+
+  void ItemEffect_GiveProgressiveMagic(game::CommonData* comData, s16 arg1, s16 arg2) {
+#if defined ENABLE_DEBUG || DEBUG_PRINT
+    util::Print("%s: Current magic acquired == %u\n", __func__, comData->save.player.magic_acquired);
+#endif
+    if (comData->save.player.magic_acquired != 0) {
+      ItemEffect_GiveDoubleMagic(comData, arg1, arg2);
+    } else {
+      ItemEffect_GiveMagic(comData, arg1, arg2);
+    }
   }
 
   void ItemEffect_GiveOcarina(game::CommonData* comData, s16 arg1, s16 arg2) {
@@ -305,14 +324,6 @@ namespace rnd {
         comData->save.inventory.stone_tower_dungeon_items.map = 1;
       break;
     }
-  }
-
-  void ItemEffect_GiveMagic(game::CommonData* comData, s16 arg1, s16 arg2) {
-    comData->save.player.magic_acquired = 1;
-    comData->save.player.magic_size_type = 0;
-    comData->save.player.magic = 48;
-    comData->save.equipment.data[3].item_btns[0] = game::ItemId::DekuNuts;
-    comData->save.player.magic_num_upgrades = 0;  // Single Magic
   }
 
   void ItemEffect_GiveSkulltula(game::CommonData* comData, s16 whichHouse, s16 arg2) {

--- a/code/source/rnd/item_override.cpp
+++ b/code/source/rnd/item_override.cpp
@@ -39,8 +39,8 @@ namespace rnd {
     rItemOverrides[0].value.looksLikeItemId = 0x26;
     rItemOverrides[1].key.scene = 0x6C;
     rItemOverrides[1].key.type = ItemOverride_Type::OVR_CHEST;
-    rItemOverrides[1].value.getItemId = 0x0E;
-    rItemOverrides[1].value.looksLikeItemId = 0x0E;
+    rItemOverrides[1].value.getItemId = 0x49;
+    rItemOverrides[1].value.looksLikeItemId = 0xB3;
     rItemOverrides[2].key.scene = 0x12;
     rItemOverrides[2].key.type = ItemOverride_Type::OVR_COLLECTABLE;
     rItemOverrides[2].value.getItemId = 0x37;
@@ -108,11 +108,11 @@ namespace rnd {
     if (key.all == 0) {
       return (ItemOverride){0};
     }
-#if defined ENABLE_DEBUG || defined DEBUG_PRINT
-    rnd::util::Print(
-        "%s: Our param values:\nActor Type %#04x\nGet Item ID: %#04x\nActor ID: %#06x\n", __func__,
-        actor->actor_type, getItemId, actor->id);
-#endif
+// #if defined ENABLE_DEBUG || defined DEBUG_PRINT
+//     rnd::util::Print(
+//         "%s: Our param values:\nActor Type %#04x\nGet Item ID: %#04x\nActor ID: %#06x\n", __func__,
+//         actor->actor_type, getItemId, actor->id);
+// #endif
     return ItemOverride_LookupByKey(key);
   }
 
@@ -442,12 +442,12 @@ namespace rnd {
 
   void ItemOverride_GetItem(game::GlobalContext* gctx, game::act::Actor* fromActor,
                             game::act::Player* player, s16 incomingGetItemId) {
-    if (rActiveItemRow != NULL)
-      return;
     ItemOverride override = {0};
     s32 incomingNegative = incomingGetItemId < 0;
     if (fromActor != NULL && incomingGetItemId != 0) {
+#if defined ENABLE_DEBUG || DEBUG_PRINT
       rnd::util::Print("%s: Our actor ID is %#06x\n", __func__, fromActor->id);
+#endif
       s16 getItemId = ItemOverride_CheckNpc(fromActor->id, incomingGetItemId, incomingNegative);
       override = ItemOverride_Lookup(fromActor, (u16)gctx->scene, getItemId);
     }
@@ -457,7 +457,6 @@ namespace rnd {
       player->get_item_id = incomingGetItemId;
       return;
     }
-
     ItemOverride_Activate(override);
     s16 baseItemId = rActiveItemRow->baseItemId;
 

--- a/code/source/rnd/item_table.cpp
+++ b/code/source/rnd/item_table.cpp
@@ -109,13 +109,13 @@ namespace rnd {
           ITEM_ROW((u32)GetItemID::GI_RUPEE_BLUE, ChestType::WOODEN_SMALL,
                    (u8)game::ItemId::SmallMagicAccumulator, 0x00C8, 0x000A4, (s8)0xFF, (s8)0xFF,
                    (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_SMALL_MAGIC_JAR,
-                   (rnd::upgradeFunc)ItemUpgrade_Magic, ItemEffect_None, (s16)-1,
+                   (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1,
                    (s16)-1),  // Small Magic Jar
 
       [0x0F] = ITEM_ROW((u32)GetItemID::GI_RUPEE_BLUE, ChestType::WOODEN_SMALL,
                         (u8)game::ItemId::BigMagicAccumulator, 0x000CC, 0x000A4, (s8)0xFF, (s8)0xFF,
                         (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_BIG_MAGIC_JAR,
-                        (rnd::upgradeFunc)ItemUpgrade_Magic, ItemEffect_None, (s16)-1,
+                        (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1,
                         (s16)-1),  // Big Magic Jar
 
       [0x10] = ITEM_ROW((u32)GetItemID::GI_RUPEE_BLUE, ChestType::WOODEN_SMALL,
@@ -451,7 +451,7 @@ namespace rnd {
 
       [0x49] = ITEM_ROW(0xFF, ChestType::WOODEN_SMALL, 0xFF, 0xFF, 0x000A4, (s8)0xFF, (s8)0xFF,
                         (s8)0xFF, (s8)0xFF, (s8)0xFF, 0xFF, (rnd::upgradeFunc)ItemUpgrade_Magic,
-                        ItemEffect_None, (s16)-1, (s16)-1),  // Progressive Magic
+                        ItemEffect_GiveProgressiveMagic, (s16)-1, (s16)-1),  // Progressive Magic
 
       [0x4A] = ITEM_ROW(0xFF, ChestType::WOODEN_SMALL, 0xFF, 0xFF, 0x001FA, (s8)0xFF, (s8)0xFF,
                         (s8)0xFF, (s8)0xFF, (s8)0xFF, 0xFF, (rnd::upgradeFunc)ItemUpgrade_Sword,
@@ -1055,7 +1055,7 @@ namespace rnd {
 
       [0xB3] =
           ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG,
-                   (u8)game::ItemId::SmallMagicAccumulator, 0x000CA, 0x000A4, (s8)0xFF, (s8)0xFF,
+                   (u8)game::ItemId::SmallMagicAccumulator, 0x000C8, 0x000A4, (s8)0xFF, (s8)0xFF,
                    (s8)0xFF, (s8)0xFF, (s8)0xFF, 0xFF, (rnd::upgradeFunc)ItemUpgrade_None,
                    ItemEffect_GiveMagic, (s16)-1, (s16)-1),  // Small Magic
 

--- a/code/source/rnd/item_upgrade.cpp
+++ b/code/source/rnd/item_upgrade.cpp
@@ -44,23 +44,20 @@ namespace rnd {
   }
 
   GetItemID ItemUpgrade_Magic(game::SaveData* saveCtx, GetItemID GetItemId) {
-    rnd::util::Print("%s: Our num upgrades is %i", __func__, saveCtx->player.magic_num_upgrades);
     switch (saveCtx->player.magic_acquired) {
     case 0:
-      saveCtx->player.magic_acquired = 1;
-      saveCtx->player.magic_size_type = 0;
-      saveCtx->player.magic = 48;
-      saveCtx->equipment.data[3].item_btns[0] = game::ItemId::DekuNuts;
-      saveCtx->player.magic_num_upgrades = 0;  // Single Magic
-      return GetItemID::GI_MAGIC_POT_SMALL;
+      return (GetItemID)0xB3;
     default:
-      saveCtx->player.magic_acquired = 1;
-      saveCtx->player.magic_size_type = 2;
-      saveCtx->player.magic = 96;
-      saveCtx->equipment.data[3].item_btns[0] = game::ItemId::DekuNuts;
-      saveCtx->player.magic_num_upgrades = 1;  // Double Magic
-      return GetItemID::GI_MAGIC_POT_LARGE;
+      return (GetItemID)0x2B;
     }
+  }
+
+  GetItemID ItemUpgrade_LargeMagic(game::SaveData* saveCtx, GetItemID GetItemId) {
+    return GetItemID::GI_MAGIC_POT_LARGE;
+  }
+
+  GetItemID ItemUpgrade_SmallMagic(game::SaveData* saveCtx, GetItemID GetItemId) {
+    return GetItemID::GI_MAGIC_POT_SMALL;
   }
 
   GetItemID ItemUpgrade_Sword(game::SaveData* saveCtx, GetItemID GetItemId) {


### PR DESCRIPTION
Looks like I put in the upgrades for magic in the wrong place way back when which was causing users to get magic when they would just walk to chests, and then breaking free standing item gets. This should resolve it and actually fix progressive magic upgrades.