### PR TITLE
Chest Overrides

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -23,7 +23,7 @@ BreakBeforeBinaryOperators: None
 BreakBeforeBraces: Attach
 BreakBeforeTernaryOperators: false
 BreakConstructorInitializersBeforeComma: false
-ColumnLimit:     100
+ColumnLimit:     120
 CommentPragmas:  '^ (IWYU pragma:|NOLINT)'
 ConstructorInitializerAllOnOneLineOrOnePerLine: false
 ConstructorInitializerIndentWidth: 4

--- a/code/include/common/bitfield.h
+++ b/code/include/common/bitfield.h
@@ -157,8 +157,8 @@ private:
   // T is an enumeration. Note that T is wrapped within an enable_if in the
   // former case to workaround compile errors which arise when using
   // std::underlying_type<T>::type directly.
-  using StorageType = typename std::conditional_t<std::is_enum<T>::value, std::underlying_type<T>,
-                                                  std::enable_if<true, T>>::type;
+  using StorageType =
+      typename std::conditional_t<std::is_enum<T>::value, std::underlying_type<T>, std::enable_if<true, T>>::type;
 
   // Unsigned version of StorageType
   using StorageTypeU = std::make_unsigned_t<StorageType>;

--- a/code/include/common/flags.h
+++ b/code/include/common/flags.h
@@ -30,9 +30,7 @@ namespace rnd {
         Clear(v);
     }
 
-    constexpr bool IsSet(FlagType v) const {
-      return (flags & std::underlying_type_t<FlagType>(v)) != 0;
-    }
+    constexpr bool IsSet(FlagType v) const { return (flags & std::underlying_type_t<FlagType>(v)) != 0; }
 
     constexpr bool TestAndClear(FlagType v) {
       if (!IsSet(v))
@@ -60,9 +58,7 @@ namespace rnd {
   public:
     constexpr void Set(IndexType idx) { GetWord(idx) |= 1 << (size_t(idx) % NumBitsPerWord); }
     constexpr void Clear(IndexType idx) { GetWord(idx) &= ~(1 << (size_t(idx) % NumBitsPerWord)); }
-    constexpr bool IsSet(IndexType idx) const {
-      return (GetWord(idx) & (1 << (size_t(idx) % NumBitsPerWord))) != 0;
-    }
+    constexpr bool IsSet(IndexType idx) const { return (GetWord(idx) & (1 << (size_t(idx) % NumBitsPerWord))) != 0; }
 
     constexpr bool TestAndClear(IndexType idx) {
       if (!IsSet(idx))
@@ -81,9 +77,7 @@ namespace rnd {
     static constexpr size_t NumBitsPerWord = sizeof(WordType) * 8;
     static constexpr size_t NumWords = (N + NumBitsPerWord - 1) / NumBitsPerWord;
     constexpr WordType& GetWord(IndexType idx) { return m_storage[size_t(idx) / NumBitsPerWord]; }
-    constexpr const WordType& GetWord(IndexType idx) const {
-      return m_storage[size_t(idx) / NumBitsPerWord];
-    }
+    constexpr const WordType& GetWord(IndexType idx) const { return m_storage[size_t(idx) / NumBitsPerWord]; }
     std::array<WordType, NumWords> m_storage{};
   };
 

--- a/code/include/csvc.h
+++ b/code/include/csvc.h
@@ -22,10 +22,9 @@
 
 /// Operations for svcControlService
 typedef enum ServiceOp {
-  SERVICEOP_STEAL_CLIENT_SESSION =
-      0,               ///< Steal a client session given a service or global port name
-  SERVICEOP_GET_NAME,  ///< Get the name of a service or global port given a client or session
-                       ///< handle
+  SERVICEOP_STEAL_CLIENT_SESSION = 0,  ///< Steal a client session given a service or global port name
+  SERVICEOP_GET_NAME,                  ///< Get the name of a service or global port given a client or session
+                                       ///< handle
 } ServiceOp;
 
 /**
@@ -114,8 +113,7 @@ Result svcQueryMemory(MemInfo* info, PageInfo* out, u32 addr);
  *
  * @sa svcControlMemory
  */
-Result svcControlMemoryEx(u32* addr_out, u32 addr0, u32 addr1, u32 size, MemOp op, MemPerm perm,
-                          bool isLoader);
+Result svcControlMemoryEx(u32* addr_out, u32 addr0, u32 addr1, u32 size, MemOp op, MemPerm perm, bool isLoader);
 ///@}
 
 ///@name System

--- a/code/include/game/context.h
+++ b/code/include/game/context.h
@@ -153,9 +153,7 @@ namespace game {
 
   // Likely incomplete.
   struct GlobalContext : State {
-    bool IsPaused() const {
-      return pause_flags.IsOneSet(PauseFlag::PauseCalc, PauseFlag::PauseDraw);
-    }
+    bool IsPaused() const { return pause_flags.IsOneSet(PauseFlag::PauseCalc, PauseFlag::PauseDraw); }
 
     act::Actor* FindActorWithId(act::Id id, act::Type type) const;
     template <typename T>
@@ -169,8 +167,7 @@ namespace game {
 
     act::Player* GetPlayerActor() const;
 
-    act::Actor* SpawnActor(act::Actor* actor, act::Id id, u16 rx, u16 ry, u16 rz, u16 param,
-                           z3dVec3f pos);
+    act::Actor* SpawnActor(act::Actor* actor, act::Id id, u16 rx, u16 ry, u16 rz, u16 param, z3dVec3f pos);
     act::Actor* SpawnActor(act::Id id, u16 rx, u16 ry, u16 rz, u16 param, z3dVec3f pos);
     void ChangeActorType(act::Actor& actor, act::Type type);
 

--- a/code/include/game/items.h
+++ b/code/include/game/items.h
@@ -170,10 +170,10 @@ namespace game {
     TenSticksAgain = 0x8c,
     FiveNuts = 0x8d,
     TenNuts = 0x8e,
-    FiveBombs = 0x8f,  // These are no item above head and allows player to move around with textbox
-                       // for GetItem Tables.
-    TenBombs = 0x90,   // These are no item above head and allows player to move around with textbox
-                       // for GetItem Tables.
+    FiveBombs = 0x8f,    // These are no item above head and allows player to move around with textbox
+                         // for GetItem Tables.
+    TenBombs = 0x90,     // These are no item above head and allows player to move around with textbox
+                         // for GetItem Tables.
     TwentyBombs = 0x91,  // These are no item above head and allows player to move around with
                          // textbox for GetItem Tables.
     ThirtyBombs = 0x92,  // These are no item above head and allows player to move around with
@@ -215,18 +215,14 @@ namespace game {
   static_assert(sizeof(GetItemEntry) == 0x8);
 
   const ItemId MaskSlots[] = {
-      ItemId::PostmanHat,  ItemId::AllNightMask,     ItemId::StoneMask,
-      ItemId::BlastMask,   ItemId::GreatFairyMask,   ItemId::DekuMask,
-      ItemId::KeatonMask,  ItemId::BremenMask,       ItemId::BunnyHood,
-      ItemId::DonGeroMask, ItemId::MaskOfScents,     ItemId::GoronMask,
-      ItemId::RomaniMask,  ItemId::CircusLeaderMask, ItemId::KafeiMask,
-      ItemId::CoupleMask,  ItemId::MaskOfTruth,      ItemId::ZoraMask,
-      ItemId::KamaroMask,  ItemId::GibdoMask,        ItemId::GaroMask,
-      ItemId::CaptainHat,  ItemId::GiantMask,        ItemId::FierceDeityMask};
+      ItemId::PostmanHat,   ItemId::AllNightMask, ItemId::StoneMask,  ItemId::BlastMask,        ItemId::GreatFairyMask,
+      ItemId::DekuMask,     ItemId::KeatonMask,   ItemId::BremenMask, ItemId::BunnyHood,        ItemId::DonGeroMask,
+      ItemId::MaskOfScents, ItemId::GoronMask,    ItemId::RomaniMask, ItemId::CircusLeaderMask, ItemId::KafeiMask,
+      ItemId::CoupleMask,   ItemId::MaskOfTruth,  ItemId::ZoraMask,   ItemId::KamaroMask,       ItemId::GibdoMask,
+      ItemId::GaroMask,     ItemId::CaptainHat,   ItemId::GiantMask,  ItemId::FierceDeityMask};
 
   // Ordered from inventory.cpp.
-  const u32 MaskSlotsOrdered[] = {0,  1,  3,  2,  4,  5,  6,  7,  8,  9,  10, 11,
-                                  12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23};
+  const u32 MaskSlotsOrdered[] = {0, 1, 3, 2, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23};
 
   constexpr bool ItemIsBottled(ItemId item) {
     return ItemId::Bottle <= item && item <= ItemId::MysteryMilkSpoiled;

--- a/code/include/game/ui.h
+++ b/code/include/game/ui.h
@@ -249,8 +249,7 @@ namespace game::ui {
     virtual void init0(LayoutBase* layout, const char* name);
     virtual void init(LayoutBase* layout, const char* name);
     virtual void reset();
-    virtual void calc(z3d_nn_math_MTX34& mtx, z3dVec4f& vec, z3d_nn_math_MTX23& mtx23, int,
-                      float time_delta);
+    virtual void calc(z3d_nn_math_MTX34& mtx, z3dVec4f& vec, z3d_nn_math_MTX23& mtx23, int, float time_delta);
 
     const char* GetName() const { return name; }
     WidgetType GetType() const;
@@ -387,11 +386,10 @@ namespace game::ui {
   class LayoutBase {
   public:
     virtual ~LayoutBase();
-    virtual void init(LayoutClass*, MainWidget** main_widgets, int num_main_widgets,
-                      AnimPlayer** players, int num_players, const char* name);
+    virtual void init(LayoutClass*, MainWidget** main_widgets, int num_main_widgets, AnimPlayer** players,
+                      int num_players, const char* name);
     virtual void m3();
-    virtual void calc(z3d_nn_math_MTX34& mtx, z3dVec4f& vec, z3d_nn_math_MTX23& mtx2, int,
-                      float time_delta);
+    virtual void calc(z3d_nn_math_MTX34& mtx, z3dVec4f& vec, z3d_nn_math_MTX23& mtx2, int, float time_delta);
 
     void calc(float time_delta = 0.033333);
 
@@ -421,8 +419,7 @@ namespace game::ui {
   public:
     // Usually called from the calc function to detect on-screen button presses and update button
     // state accordingly.
-    virtual void HandleTouch(bool a, bool b, bool c, ScreenContext& ctx, int d, float time_delta,
-                             float x, float y);
+    virtual void HandleTouch(bool a, bool b, bool c, ScreenContext& ctx, int d, float time_delta, float x, float y);
     virtual void m6();
     virtual void DoInit();
     virtual void m8();

--- a/code/include/newcodeinfo.h
+++ b/code/include/newcodeinfo.h
@@ -7,7 +7,6 @@
 #define _NEWCODEINFO_H_
 
 #define NEWCODE_OFFSET 0x007D0000
-#define NEWCODE_SIZE                                                                               \
-  0x00050000  // TODO: Probably too large for this patch but it is the size of restoration.
+#define NEWCODE_SIZE 0x00050000  // TODO: Probably too large for this patch but it is the size of restoration.
 
 #endif  //_NEWCODEINFO_H_

--- a/code/include/rnd/extdata.h
+++ b/code/include/rnd/extdata.h
@@ -116,7 +116,7 @@ namespace rnd {
  * @param fsa FS_Archive : The archive obtained from extDataMount.
  * @param filename char* : The path to the file to open in the extData.
  */
-#define extDataOpen(out, fsa, filename)                                                            \
+#define extDataOpen(out, fsa, filename)                                                                                \
   FSUSER_OpenFile(out, fsa, fsMakePath(PATH_ASCII, filename), FS_OPEN_WRITE | FS_OPEN_READ, 0)
 
 /**

--- a/code/include/rnd/item_override.h
+++ b/code/include/rnd/item_override.h
@@ -28,11 +28,11 @@ namespace rnd {
     /* 0x0E */ GI_MAGIC_POT_SMALL,              // Item above head, no animation like 0x01.
     /* 0x0F */ GI_MAGIC_POT_LARGE,              // Item above head, no animation like 0x01.
     /* 0x10 */ GI_RECOVERY_HEART_SINGLE_THREE,  // No actor, just sound and recovery.
-    /* 0x11 */  // GI_ERROR_NOTHING_11, // Item above head, no animation like 0x01.
+    /* 0x11 */                                  // GI_ERROR_NOTHING_11, // Item above head, no animation like 0x01.
     /* 0x12 */ GI_RECOVERY_HEART_SINGLE_FOUR = 0x12,  // No actor, just sound and recovery.
     /* 0x13 */ GI_RECOVERY_HEART_SINGLE_FIVE,         // No actor, just sound and recovery.,
-    /* 0x14 */ GI_BOMBS_1,  // Item above head, no animation like 0x01. Bomb bag required.
-    /* 0x15 */ GI_BOMBS_5,  // Item above head, no animation like 0x01.
+    /* 0x14 */ GI_BOMBS_1,                            // Item above head, no animation like 0x01. Bomb bag required.
+    /* 0x15 */ GI_BOMBS_5,                            // Item above head, no animation like 0x01.
     /* 0x16 */ GI_BOMBS_10,
     /* 0x17 */ GI_BOMBS_20,
     /* 0x18 */ GI_BOMBS_30,
@@ -79,8 +79,8 @@ namespace rnd {
     /* 0x40 */ GI_ERROR_NOTHING_40,  // ***ERROR TEXT Get Item Nothing in hand - Green Rupee with
                                      // Ocarina in Inventory
                                      // XXX: ICE TRAP
-    /* 0x41 */ GI_HOOKSHOT,  // ***ERROR TEXT Get Item Nothing in hand - Green Rupee with Ocarina in
-                             // Inventory
+    /* 0x41 */ GI_HOOKSHOT,          // ***ERROR TEXT Get Item Nothing in hand - Green Rupee with Ocarina in
+                                     // Inventory
     /* 0x42 */ GI_LENS_OF_TRUTH = 0x42,
     /* 0x43 */ GI_PICTOGRAPH_BOX = 0x43,
     /* 0x44 */  // GI_ERROR_PICTOGRAPH_BOX, // ***ERROR TEXT Get Item Nothing in hand - Gives
@@ -108,8 +108,7 @@ namespace rnd {
     /* 0x50 */ GI_BOMBERS_NOTEBOOK = 0x50,
     /* 0x51 */  // GI_ERROR_YELLOW_RUPPEE, // ***ERROR TEXT Get Item Nothing in hand at first - then
                 // subsequently yellow rupee. No rupee increment.
-    /* 0x52 */ GI_GOLD_SKULLTULA_SPIRIT =
-        0x52,   // Pickup model is whacky since we usually don't have one.
+    /* 0x52 */ GI_GOLD_SKULLTULA_SPIRIT = 0x52,  // Pickup model is whacky since we usually don't have one.
     /* 0x53 */  // GI_ERROR_NOTHING_53, // ***ERROR TEXT Get Item Nothing in hand - Green Rupee with
                 // Ocarina in Inventory
     /* 0x54 */  // GI_ERROR_NOTHING_54, // ***ERROR TEXT Get Item Nothing in hand - Green Rupee with
@@ -120,7 +119,7 @@ namespace rnd {
     /* 0x58 */ GI_TWINMOLDS_REMAINS,       // Also softlocks!
     /* 0x59 */ GI_BOTTLE_POTION_RED,
     /* 0x5A */ GI_BOTTLE_EMPTY,
-    /* 0x5B */ GI_POTION_RED,  // If all bottles in item screen are full, it gives recovery hearts.
+    /* 0x5B */ GI_POTION_RED,           // If all bottles in item screen are full, it gives recovery hearts.
     /* 0x5C */ GI_POTION_GREEN,         // Does not give new bottles.
     /* 0x5D */ GI_POTION_BLUE,          // Does not give new bottles.
     /* 0x5E */ GI_FAIRY,                // Does not give new bottles.
@@ -182,15 +181,14 @@ namespace rnd {
     /* 0x8F */ GI_MASK_KAFEIS,
     /* 0x90 */  // GI_ERROR_NOTHING_90, // ***ERROR TEXT Get Item Nothing in hand - Green Rupee with
                 // Ocarina in Inventory
-    /* 0x91 */ GI_BOTTLE_CHATEAU_ROMANI_TWO =
-        0x91,  // Sets it in a different slot if no bottle present. Second bottle?
-    /* 0x92 */ GI_BOTTLE_MILK_TWO,       // Sets it in a different slot if no bottle present. Second
-                                         // bottle?
-    /* 0x93 */ GI_BOTTLE_GOLD_DUST_TWO,  // Sets it in a different slot if no bottle present. Second
-                                         // bottle?
-    /* 0x94 */ GI_BOTTLE_MYSTERY_MILK_TWO,  // Timer set to 0.
-    /* 0x95 */ GI_BOTTLE_SEAHORSE_TWO,      // Proper sea horse actor!
-    /* 0x96 */ GI_MOONS_TEAR,               // Provides a black screen after collecting in citra.
+    /* 0x91 */ GI_BOTTLE_CHATEAU_ROMANI_TWO = 0x91,  // Sets it in a different slot if no bottle present. Second bottle?
+    /* 0x92 */ GI_BOTTLE_MILK_TWO,                   // Sets it in a different slot if no bottle present. Second
+                                                     // bottle?
+    /* 0x93 */ GI_BOTTLE_GOLD_DUST_TWO,              // Sets it in a different slot if no bottle present. Second
+                                                     // bottle?
+    /* 0x94 */ GI_BOTTLE_MYSTERY_MILK_TWO,           // Timer set to 0.
+    /* 0x95 */ GI_BOTTLE_SEAHORSE_TWO,               // Proper sea horse actor!
+    /* 0x96 */ GI_MOONS_TEAR,                        // Provides a black screen after collecting in citra.
     /* 0x97 */ GI_TOWN_TITLE_DEED,
     /* 0x98 */ GI_SWAMP_TITLE_DEED,
     /* 0x99 */ GI_MOUNTAIN_TITLE_DEED,
@@ -203,19 +201,19 @@ namespace rnd {
                                          // take with a grain of salt
     /* 0xA0 */ GI_ROOM_KEY,              // Softlocks if you go to the room
     /* 0xA1 */ GI_LETTER_TO_MAMA,
-    /* 0xA2 */  // GI_ERROR_NOTHING_A2, // ***ERROR TEXT Get Item Nothing in hand - Green Rupee with
-                // Ocarina in Inventory
-    /* 0xA3 */  // GI_ERROR_NOTHING_A3, // ***ERROR TEXT Get Item Nothing in hand - Green Rupee with
-                // Ocarina in Inventory
-    /* 0xA4 */  // GI_ERROR_NOTHING_A4, // ***ERROR TEXT Get Item Keaton Mask if do not have.
-    /* 0xA5 */  // GI_ERROR_NOTHING_A5, // ***ERROR TEXT Get Item Nothing in hand - Green Rupee with
-                // Ocarina in Inventory
-    /* 0xA6 */  // GI_ERROR_NOTHING_A6, // ***ERROR TEXT Get Item Nothing in hand - Green Rupee with
-                // Ocarina in Inventory
-    /* 0xA7 */  // GI_ERROR_NOTHING_A7, // ***ERROR TEXT Get Item Nothing in hand - Green Rupee with
-                // Ocarina in Inventory
-    /* 0xA8 */  // GI_ERROR_NOTHING_A8, // ***ERROR TEXT Get Item Nothing in hand - Green Rupee with
-                // Ocarina in Inventory,
+    /* 0xA2 */                    // GI_ERROR_NOTHING_A2, // ***ERROR TEXT Get Item Nothing in hand - Green Rupee with
+                                  // Ocarina in Inventory
+    /* 0xA3 */                    // GI_ERROR_NOTHING_A3, // ***ERROR TEXT Get Item Nothing in hand - Green Rupee with
+                                  // Ocarina in Inventory
+    /* 0xA4 */                    // GI_ERROR_NOTHING_A4, // ***ERROR TEXT Get Item Keaton Mask if do not have.
+    /* 0xA5 */                    // GI_ERROR_NOTHING_A5, // ***ERROR TEXT Get Item Nothing in hand - Green Rupee with
+                                  // Ocarina in Inventory
+    /* 0xA6 */                    // GI_ERROR_NOTHING_A6, // ***ERROR TEXT Get Item Nothing in hand - Green Rupee with
+                                  // Ocarina in Inventory
+    /* 0xA7 */                    // GI_ERROR_NOTHING_A7, // ***ERROR TEXT Get Item Nothing in hand - Green Rupee with
+                                  // Ocarina in Inventory
+    /* 0xA8 */                    // GI_ERROR_NOTHING_A8, // ***ERROR TEXT Get Item Nothing in hand - Green Rupee with
+                                  // Ocarina in Inventory,
     /* 0xA9 */ GI_BOTTLE = 0xA9,  // Bottle purchase back text.
     /* 0xAA */ GI_LETTER_TO_KAFEI,
     /* 0xAB */ GI_PENDANT_OF_MEMORIES,
@@ -434,8 +432,7 @@ namespace rnd {
   void ItemOverride_CheckStartingItem();
   void ItemOverride_Init();
   void ItemOverride_Update();
-  extern "C" void ItemOverride_GetItem(game::GlobalContext*, game::act::Actor*, game::act::Player*,
-                                       s16);
+  extern "C" void ItemOverride_GetItem(game::GlobalContext*, game::act::Actor*, game::act::Player*, s16);
   extern "C" void ItemOverride_GetFairyRewardItem(game::GlobalContext*, game::act::Actor*, s16);
   extern "C" void ItemOverride_GetItemTextAndItemID(game::act::Player*);
   extern "C" u32 rActiveItemGraphicId;

--- a/code/include/rnd/savefile.h
+++ b/code/include/rnd/savefile.h
@@ -38,6 +38,7 @@ namespace rnd {
     s8 aromaGivenItem;
     s8 grannyGaveReward;
     s8 stoneMaskReward;
+    s8 gaveFairyMaskReward;
     u8 chestRewarded[116][187]; // Reward table that's stored by scene and item.
   } ExtSaveData;
 

--- a/code/include/rnd/savefile.h
+++ b/code/include/rnd/savefile.h
@@ -39,7 +39,7 @@ namespace rnd {
     s8 grannyGaveReward;
     s8 stoneMaskReward;
     s8 gaveFairyMaskReward;
-    u8 chestRewarded[116][187]; // Reward table that's stored by scene and item.
+    u8 chestRewarded[116][30]; // Reward table that's stored by scene and chest param/flag.
   } ExtSaveData;
 
   extern "C" ExtSaveData gExtSaveData;

--- a/code/include/rnd/savefile.h
+++ b/code/include/rnd/savefile.h
@@ -6,7 +6,7 @@
 #include "z3d/z3DVec.h"
 
 // Increment the version number whenever the ExtSaveData structure is changed
-#define EXTSAVEDATA_VERSION 01
+#define EXTSAVEDATA_VERSION 02
 
 namespace rnd {
   void SaveFile_SkipMinorCutscenes();
@@ -38,6 +38,7 @@ namespace rnd {
     s8 aromaGivenItem;
     s8 grannyGaveReward;
     s8 stoneMaskReward;
+    u8 chestRewarded[116][187]; // Reward table that's stored by scene and item.
   } ExtSaveData;
 
   extern "C" ExtSaveData gExtSaveData;

--- a/code/include/rnd/savefile.h
+++ b/code/include/rnd/savefile.h
@@ -39,7 +39,7 @@ namespace rnd {
     s8 grannyGaveReward;
     s8 stoneMaskReward;
     s8 gaveFairyMaskReward;
-    u8 chestRewarded[116][30]; // Reward table that's stored by scene and chest param/flag.
+    u8 chestRewarded[116][30];  // Reward table that's stored by scene and chest param/flag.
   } ExtSaveData;
 
   extern "C" ExtSaveData gExtSaveData;

--- a/code/include/utils.h
+++ b/code/include/utils.h
@@ -46,8 +46,7 @@ static inline u32 makeARMBranch(const void* src, const void* dst,
 {
   u32 instrBase = link ? 0xEB000000 : 0xEA000000;
   u32 off = (u32)((const u8*)dst -
-                  ((const u8*)src +
-                   8));  // the PC is always two instructions ahead of the one being executed
+                  ((const u8*)src + 8));  // the PC is always two instructions ahead of the one being executed
 
   return instrBase | ((off >> 2) & 0xFFFFFF);
 }

--- a/code/mm.ld
+++ b/code/mm.ld
@@ -24,9 +24,9 @@ SECTIONS{
 		*(.patch_DecoupleStartSelect)
 	}
 
-	.patch_AttemptKeepChestsClosed 0x1c9300 : {
+	/* .patch_AttemptKeepChestsClosed 0x1c9300 : {
 		*(.patch_AttemptKeepChestsClosed)
-	}
+	} */
 
 	.patch_DoNotRemoveKeys 0x1c9b94 : {
 		*(.patch_DoNotRemoveKeys)

--- a/code/mm.ld
+++ b/code/mm.ld
@@ -108,7 +108,7 @@ SECTIONS{
 		*(.patch_OverrideItemID)
 	}
 
-	.patch_OverrideFairyGiveItemOne 0x3BECB4 : {
+	.patch_OverrideFairyGiveItemOne 0x3BECB8 : {
 		*(.patch_OverrideFairyGiveItemOne)
 	}
 

--- a/code/mm.ld
+++ b/code/mm.ld
@@ -112,6 +112,10 @@ SECTIONS{
 		*(.patch_OverrideFairyGiveItemOne)
 	}
 
+	/* .patch_OverrideFairyItemAnonStruct 0x3BECD4 : {
+		*(.patch_OverrideFairyItemAnonStruct)
+	} */
+
 	/* .patch_OverrideGreatFairyText 0x3b783c : {
 		*(.patch_OverrideGreatFairyText)
 	}*/

--- a/code/source/asm/hooks.s
+++ b/code/source/asm/hooks.s
@@ -150,13 +150,21 @@ hook_OverrideFairyItemID:
     push {r0-r12, lr}
     cpy r0,r5
     cpy r1,r4
-    mov r2,#0x40
     bl ItemOverride_GetFairyRewardItem
+    ldr r5,.rActiveItemRow_addr
+    ldr r5,[r5]
+    cmp r5,#0x0
+    pop {r0-r12, lr}
+    beq noOverrideFairyItemID
+    push {r0-r12, lr}
+    cpy r0,r5
+    cpy r1,r4
     bl ItemOverride_GetItemTextAndItemID
     pop {r0-r12, lr}
+    cpy r0,r5
     b 0x3BECC0
 noOverrideFairyItemID:
-    mov r1,#0x40
+    cpy r0,r5
     b 0x3BECBC
 
 .global hook_IncomingGetItemID

--- a/code/source/asm/loader.c
+++ b/code/source/asm/loader.c
@@ -9,8 +9,7 @@
 Result svcOpenProcess_mine(Handle* process, u32 processId);
 Result svcGetProcessId_mine(u32* out, Handle handle);
 void svcBreak_mine(UserBreakType breakReason);
-Result svcControlProcessMemory_mine(Handle process, u32 addr0, u32 addr1, u32 size, u32 type,
-                                    u32 perm);
+Result svcControlProcessMemory_mine(Handle process, u32 addr0, u32 addr1, u32 size, u32 type, u32 perm);
 
 void loader_main(void) __attribute__((section(".loader")));
 Handle getCurrentProcessHandle(void) __attribute__((section(".loader")));
@@ -21,15 +20,14 @@ void loader_main(void) {
   u32 address = NEWCODE_OFFSET;
   u32 neededMemory = (NEWCODE_SIZE + 0xFFF) & ~0xFFF;  // rounding up
 
-  res =
-      svcControlProcessMemory_mine(getCurrentProcessHandle(), address, address, neededMemory, 6, 7);
+  res = svcControlProcessMemory_mine(getCurrentProcessHandle(), address, address, neededMemory, 6, 7);
 
   if (res < 0)
     svcBreak_mine(USERBREAK_ASSERT);
 
   // Hacky solution to be able to edit gDrawItemTable, which is normally in RO data
-  res = svcControlProcessMemory_mine(getCurrentProcessHandle(), 0x4D8000, 0x4D8000, 0x1000,
-                                     MEMOP_PROT, MEMPERM_READ | MEMPERM_WRITE);
+  res = svcControlProcessMemory_mine(getCurrentProcessHandle(), 0x4D8000, 0x4D8000, 0x1000, MEMOP_PROT,
+                                     MEMPERM_READ | MEMPERM_WRITE);
 
   if (res < 0)
     svcBreak_mine(USERBREAK_ASSERT);

--- a/code/source/common/printf.cpp
+++ b/code/source/common/printf.cpp
@@ -159,8 +159,8 @@ static unsigned int _atoi(const char** str) {
 }
 
 // output the specified string in reverse, taking care of any zero-padding
-static size_t _out_rev(out_fct_type out, char* buffer, size_t idx, size_t maxlen, const char* buf,
-                       size_t len, unsigned int width, unsigned int flags) {
+static size_t _out_rev(out_fct_type out, char* buffer, size_t idx, size_t maxlen, const char* buf, size_t len,
+                       unsigned int width, unsigned int flags) {
   const size_t start_idx = idx;
 
   // pad spaces up to given width
@@ -186,9 +186,8 @@ static size_t _out_rev(out_fct_type out, char* buffer, size_t idx, size_t maxlen
 }
 
 // internal itoa format
-static size_t _ntoa_format(out_fct_type out, char* buffer, size_t idx, size_t maxlen, char* buf,
-                           size_t len, bool negative, bool hex, unsigned int prec,
-                           unsigned int width, unsigned int flags) {
+static size_t _ntoa_format(out_fct_type out, char* buffer, size_t idx, size_t maxlen, char* buf, size_t len,
+                           bool negative, bool hex, unsigned int prec, unsigned int width, unsigned int flags) {
   // pad leading zeros
   if (!(flags & FLAGS_LEFT)) {
     if (width && (flags & FLAGS_ZEROPAD) && (negative || (flags & (FLAGS_PLUS | FLAGS_SPACE)))) {
@@ -234,9 +233,8 @@ static size_t _ntoa_format(out_fct_type out, char* buffer, size_t idx, size_t ma
 }
 
 // internal itoa for 'long' type
-static size_t _ntoa_long(out_fct_type out, char* buffer, size_t idx, size_t maxlen,
-                         unsigned long value, bool negative, bool hex, unsigned int prec,
-                         unsigned int width, unsigned int flags) {
+static size_t _ntoa_long(out_fct_type out, char* buffer, size_t idx, size_t maxlen, unsigned long value, bool negative,
+                         bool hex, unsigned int prec, unsigned int width, unsigned int flags) {
   char buf[PRINTF_NTOA_BUFFER_SIZE];
   size_t len = 0U;
 
@@ -267,20 +265,19 @@ static size_t _ntoa_long(out_fct_type out, char* buffer, size_t idx, size_t maxl
 
 #if defined(PRINTF_SUPPORT_EXPONENTIAL)
 // forward declaration so that _ftoa can switch to exp notation for values > PRINTF_MAX_FLOAT
-static size_t _etoa(out_fct_type out, char* buffer, size_t idx, size_t maxlen, double value,
-                    unsigned int prec, unsigned int width, unsigned int flags);
+static size_t _etoa(out_fct_type out, char* buffer, size_t idx, size_t maxlen, double value, unsigned int prec,
+                    unsigned int width, unsigned int flags);
 #endif
 
 // internal ftoa for fixed decimal floating point
-static size_t _ftoa(out_fct_type out, char* buffer, size_t idx, size_t maxlen, double value,
-                    unsigned int prec, unsigned int width, unsigned int flags) {
+static size_t _ftoa(out_fct_type out, char* buffer, size_t idx, size_t maxlen, double value, unsigned int prec,
+                    unsigned int width, unsigned int flags) {
   char buf[PRINTF_FTOA_BUFFER_SIZE];
   size_t len = 0U;
   double diff = 0.0;
 
   // powers of 10
-  static const double pow10[] = {1,      10,      100,      1000,      10000,
-                                 100000, 1000000, 10000000, 100000000, 1000000000};
+  static const double pow10[] = {1, 10, 100, 1000, 10000, 100000, 1000000, 10000000, 100000000, 1000000000};
 
   // test for special values
   if (value != value)
@@ -288,8 +285,8 @@ static size_t _ftoa(out_fct_type out, char* buffer, size_t idx, size_t maxlen, d
   if (value < -DBL_MAX)
     return _out_rev(out, buffer, idx, maxlen, "fni-", 4, width, flags);
   if (value > DBL_MAX)
-    return _out_rev(out, buffer, idx, maxlen, (flags & FLAGS_PLUS) ? "fni+" : "fni",
-                    (flags & FLAGS_PLUS) ? 4U : 3U, width, flags);
+    return _out_rev(out, buffer, idx, maxlen, (flags & FLAGS_PLUS) ? "fni+" : "fni", (flags & FLAGS_PLUS) ? 4U : 3U,
+                    width, flags);
 
   // test for very large values
   // standard printf behavior is to print EVERY whole number digit -- which could be 100s of
@@ -398,8 +395,8 @@ static size_t _ftoa(out_fct_type out, char* buffer, size_t idx, size_t maxlen, d
 #if defined(PRINTF_SUPPORT_EXPONENTIAL)
 // internal ftoa variant for exponential floating-point type, contributed by Martijn Jasperse
 // <m.jasperse@gmail.com>
-static size_t _etoa(out_fct_type out, char* buffer, size_t idx, size_t maxlen, double value,
-                    unsigned int prec, unsigned int width, unsigned int flags) {
+static size_t _etoa(out_fct_type out, char* buffer, size_t idx, size_t maxlen, double value, unsigned int prec,
+                    unsigned int width, unsigned int flags) {
   // check for NaN and special values
   if ((value != value) || (value > DBL_MAX) || (value < -DBL_MAX)) {
     return _ftoa(out, buffer, idx, maxlen, value, prec, width, flags);
@@ -424,12 +421,10 @@ static size_t _etoa(out_fct_type out, char* buffer, size_t idx, size_t maxlen, d
   } conv;
 
   conv.F = value;
-  int exp2 = (int)((conv.U >> 52U) & 0x07FFU) - 1023;  // effectively log2
-  conv.U = (conv.U & ((1ULL << 52U) - 1U)) |
-           (1023ULL << 52U);  // drop the exponent so conv.F is now in [1,2)
+  int exp2 = (int)((conv.U >> 52U) & 0x07FFU) - 1023;           // effectively log2
+  conv.U = (conv.U & ((1ULL << 52U) - 1U)) | (1023ULL << 52U);  // drop the exponent so conv.F is now in [1,2)
   // now approximate log10 from the log2 integer part and an expansion of ln around 1.5
-  int expval =
-      (int)(0.1760912590558 + exp2 * 0.301029995663981 + (conv.F - 1.5) * 0.289529654602168);
+  int expval = (int)(0.1760912590558 + exp2 * 0.301029995663981 + (conv.F - 1.5) * 0.289529654602168);
   // now we want to compute 10^expval but we want to be sure it won't overflow
   exp2 = (int)(expval * 3.321928094887362 + 0.5);
   const double z = expval * 2.302585092994046 - exp2 * 0.6931471805599453;
@@ -489,16 +484,15 @@ static size_t _etoa(out_fct_type out, char* buffer, size_t idx, size_t maxlen, d
 
   // output the floating part
   const size_t start_idx = idx;
-  idx = _ftoa(out, buffer, idx, maxlen, negative ? -value : value, prec, fwidth,
-              flags & ~FLAGS_ADAPT_EXP);
+  idx = _ftoa(out, buffer, idx, maxlen, negative ? -value : value, prec, fwidth, flags & ~FLAGS_ADAPT_EXP);
 
   // output the exponent part
   if (minwidth) {
     // output the exponential symbol
     out((flags & FLAGS_UPPERCASE) ? 'E' : 'e', buffer, idx++, maxlen);
     // output the exponent value
-    idx = _ntoa_long(out, buffer, idx, maxlen, (expval < 0) ? -expval : expval, expval < 0, false,
-                     0, minwidth - 1, FLAGS_ZEROPAD | FLAGS_PLUS);
+    idx = _ntoa_long(out, buffer, idx, maxlen, (expval < 0) ? -expval : expval, expval < 0, false, 0, minwidth - 1,
+                     FLAGS_ZEROPAD | FLAGS_PLUS);
     // might need to right-pad spaces
     if (flags & FLAGS_LEFT) {
       while (idx - start_idx < width)
@@ -511,8 +505,7 @@ static size_t _etoa(out_fct_type out, char* buffer, size_t idx, size_t maxlen, d
 #endif  // PRINTF_SUPPORT_FLOAT
 
 // internal vsnprintf
-static int _vsnprintf(out_fct_type out, char* buffer, const size_t maxlen, const char* format,
-                      va_list va) {
+static int _vsnprintf(out_fct_type out, char* buffer, const size_t maxlen, const char* format, va_list va) {
   unsigned int flags, width, precision, n;
   size_t idx = 0U;
 
@@ -656,25 +649,23 @@ static int _vsnprintf(out_fct_type out, char* buffer, const size_t maxlen, const
         // signed
         if (flags & FLAGS_LONG) {
           const long value = va_arg(va, long);
-          idx = _ntoa_long(out, buffer, idx, maxlen, (unsigned long)(value > 0 ? value : 0 - value),
-                           value < 0, hex, precision, width, flags);
+          idx = _ntoa_long(out, buffer, idx, maxlen, (unsigned long)(value > 0 ? value : 0 - value), value < 0, hex,
+                           precision, width, flags);
         } else {
           const int value = (flags & FLAGS_CHAR)  ? (char)va_arg(va, int) :
                             (flags & FLAGS_SHORT) ? (short int)va_arg(va, int) :
                                                     va_arg(va, int);
-          idx = _ntoa_long(out, buffer, idx, maxlen, (unsigned int)(value > 0 ? value : 0 - value),
-                           value < 0, hex, precision, width, flags);
+          idx = _ntoa_long(out, buffer, idx, maxlen, (unsigned int)(value > 0 ? value : 0 - value), value < 0, hex,
+                           precision, width, flags);
         }
       } else {
         // unsigned
         if (flags & FLAGS_LONG) {
-          idx = _ntoa_long(out, buffer, idx, maxlen, va_arg(va, unsigned long), false, hex,
-                           precision, width, flags);
+          idx = _ntoa_long(out, buffer, idx, maxlen, va_arg(va, unsigned long), false, hex, precision, width, flags);
         } else {
-          const unsigned int value =
-              (flags & FLAGS_CHAR)  ? (unsigned char)va_arg(va, unsigned int) :
-              (flags & FLAGS_SHORT) ? (unsigned short int)va_arg(va, unsigned int) :
-                                      va_arg(va, unsigned int);
+          const unsigned int value = (flags & FLAGS_CHAR)  ? (unsigned char)va_arg(va, unsigned int) :
+                                     (flags & FLAGS_SHORT) ? (unsigned short int)va_arg(va, unsigned int) :
+                                                             va_arg(va, unsigned int);
           idx = _ntoa_long(out, buffer, idx, maxlen, value, false, hex, precision, width, flags);
         }
       }
@@ -752,8 +743,8 @@ static int _vsnprintf(out_fct_type out, char* buffer, const size_t maxlen, const
     case 'p': {
       width = sizeof(void*) * 2U;
       flags |= FLAGS_ZEROPAD | FLAGS_UPPERCASE;
-      idx = _ntoa_long(out, buffer, idx, maxlen, (unsigned long)((uintptr_t)va_arg(va, void*)),
-                       false, true, precision, width, flags);
+      idx = _ntoa_long(out, buffer, idx, maxlen, (unsigned long)((uintptr_t)va_arg(va, void*)), false, true, precision,
+                       width, flags);
       format++;
       break;
     }

--- a/code/source/game/context.cpp
+++ b/code/source/game/context.cpp
@@ -21,18 +21,17 @@ namespace game {
     return static_cast<act::Player*>(this->actors.lists[u8(act::Type::Player)].first);
   }
 
-  act::Actor* GlobalContext::SpawnActor(act::Actor* actor, act::Id id, u16 rx, u16 ry, u16 rz,
-                                        u16 param, z3dVec3f pos) {
-    auto spawn_actor_wrapper =
-        rnd::util::GetPointer<act::Actor*(ActorLists*, act::Actor*, GlobalContext*, act::Id, u16,
-                                          u16, u16, u16 param, z3dVec3f)>(0x22CAAC);
+  act::Actor* GlobalContext::SpawnActor(act::Actor* actor, act::Id id, u16 rx, u16 ry, u16 rz, u16 param,
+                                        z3dVec3f pos) {
+    auto spawn_actor_wrapper = rnd::util::GetPointer<act::Actor*(ActorLists*, act::Actor*, GlobalContext*, act::Id, u16,
+                                                                 u16, u16, u16 param, z3dVec3f)>(0x22CAAC);
     return spawn_actor_wrapper(&actors, actor, this, id, rx, ry, rz, param, pos);
   }
 
-  act::Actor* GlobalContext::SpawnActor(act::Id id, u16 rx, u16 ry, u16 rz, u16 param,
-                                        z3dVec3f pos) {
-    auto spawn_actor_wrapper = rnd::util::GetPointer<act::Actor*(
-        ActorLists*, GlobalContext*, act::Id, u16, u16, u16, u16 param, z3dVec3f)>(0x22074C);
+  act::Actor* GlobalContext::SpawnActor(act::Id id, u16 rx, u16 ry, u16 rz, u16 param, z3dVec3f pos) {
+    auto spawn_actor_wrapper =
+        rnd::util::GetPointer<act::Actor*(ActorLists*, GlobalContext*, act::Id, u16, u16, u16, u16 param, z3dVec3f)>(
+            0x22074C);
     return spawn_actor_wrapper(&actors, this, id, rx, ry, rz, param, pos);
   }
 
@@ -42,8 +41,7 @@ namespace game {
   }
 
   void GlobalContext::ShowMessage(u16 msgid, act::Actor* actor) {
-    rnd::util::GetPointer<void(GlobalContext*, int msgid, act::Actor*)>(0x21BAFC)(this, msgid,
-                                                                                  actor);
+    rnd::util::GetPointer<void(GlobalContext*, int msgid, act::Actor*)>(0x21BAFC)(this, msgid, actor);
   }
 
   void GlobalContext::Talk(act::Actor* actor, int a) {

--- a/code/source/game/items.cpp
+++ b/code/source/game/items.cpp
@@ -52,9 +52,8 @@ namespace game {
 
   bool HasBottle(ItemId bottle_contents) {
     const auto& bottles = GetCommonData().save.inventory.bottles;
-    return std::any_of(bottles.begin(), bottles.end(), [&](ItemId id) {
-      return bottle_contents == id && bottle_contents != game::ItemId::None;
-    });
+    return std::any_of(bottles.begin(), bottles.end(),
+                       [&](ItemId id) { return bottle_contents == id && bottle_contents != game::ItemId::None; });
   }
 
   void RemoveBottle(u32 bottle_index) {
@@ -750,8 +749,8 @@ namespace game {
   }};
 
   static bool IsBossRoomScene(GlobalContext* gctx) {
-    return rnd::util::IsAnyOf(gctx->scene, SceneId::OdolwaLair, SceneId::GohtLair,
-                              SceneId::GyorgLair, SceneId::TwinmoldLair, SceneId::MajoraLair);
+    return rnd::util::IsAnyOf(gctx->scene, SceneId::OdolwaLair, SceneId::GohtLair, SceneId::GyorgLair,
+                              SceneId::TwinmoldLair, SceneId::MajoraLair);
   }
 
   bool CanUseItem(ItemId item) {
@@ -786,14 +785,13 @@ namespace game {
     }
 
     if (gctx->scene == SceneId::SwampFishingHole || gctx->scene == SceneId::OceanFishingHole) {
-      return item == ItemId::ZoraMask || item == ItemId::FierceDeityMask ||
-             ItemIsNonTransformationMask(item) || (ItemIsTransformationMask(item) && mode < 2);
+      return item == ItemId::ZoraMask || item == ItemId::FierceDeityMask || ItemIsNonTransformationMask(item) ||
+             (ItemIsTransformationMask(item) && mode < 2);
     }
 
     const bool is_beaver_race = cdata.field_3696 == 1 && cdata.sub1.entrance == 0x8E10;
     const bool is_goron_race = cdata.sub1.entrance == 0xD010;
-    if ((is_beaver_race || is_goron_race) && !gctx->field_C529_one_to_clear_input &&
-        !gctx->field_C85A) {
+    if ((is_beaver_race || is_goron_race) && !gctx->field_C529_one_to_clear_input && !gctx->field_C85A) {
       return false;
     }
 
@@ -827,8 +825,7 @@ namespace game {
     if (player->flags1.IsSet(act::Player::Flag1::Unk200000))
       return item == ItemId::LensOfTruth;
 
-    if (player->flags1.IsSet(act::Player::Flag1::Unk2000) &&
-        cdata.usable_btns[0] != ButtonIsUsable::No) {
+    if (player->flags1.IsSet(act::Player::Flag1::Unk2000) && cdata.usable_btns[0] != ButtonIsUsable::No) {
       return false;
     }
 

--- a/code/source/game/message.cpp
+++ b/code/source/game/message.cpp
@@ -124,7 +124,7 @@ namespace game {
       auto& text = msg->texts[i];
       text.reader = rnd::util::GetPointer<MessageReader*(Language)>(0x1C519C)(Language(i));
       if (res_header->languages.IsSet(Language(i))) {
-#ifdef ENABLE_DEBUG
+#if defined ENABLE_DEBUG || defined DEBUG_PRINT
 // rnd::util::Print("%s: Here's some info for text length: %u\n", __func__,
 // entry->texts[res_idx].length);
 #endif

--- a/code/source/game/message.cpp
+++ b/code/source/game/message.cpp
@@ -44,8 +44,7 @@ namespace game {
     int customEnd = numCustomMessageEntries - 1;
     bool isCustom = false;
     const auto get_entry = [this](size_t idx) {
-      return reinterpret_cast<const MessageResEntry*>((const u8*)res_entries +
-                                                      res_entry_size * idx);
+      return reinterpret_cast<const MessageResEntry*>((const u8*)res_entries + res_entry_size * idx);
     };
     const auto get_custom_entry = [this](size_t idx) {
       return reinterpret_cast<const MessageResEntry*>((const u8*)ptrCustomMessageEntries + idx);
@@ -128,8 +127,7 @@ namespace game {
 // rnd::util::Print("%s: Here's some info for text length: %u\n", __func__,
 // entry->texts[res_idx].length);
 #endif
-        text.ptr = isCustom ? (u8*)entry->texts[res_idx].offset :
-                              (u8*)res_header + (u32)entry->texts[res_idx].offset;
+        text.ptr = isCustom ? (u8*)entry->texts[res_idx].offset : (u8*)res_header + (u32)entry->texts[res_idx].offset;
         text.size = entry->texts[res_idx].length;
         ++res_idx;
       } else {

--- a/code/source/game/objectbankarchive.cpp
+++ b/code/source/game/objectbankarchive.cpp
@@ -2,14 +2,13 @@
 
 namespace game::ObjectBank {
   // set_field_5c always = 0 in code calls.
-  void init(ObjectBankArchive* obj_bank_archive, u32 actor_id, ResArchiveHeader* data, int size,
-            char set_field_5c) {
-    return rnd::util::GetPointer<void(ObjectBankArchive*, u32, ResArchiveHeader*, int, char)>(
-        0x1F57DC)(obj_bank_archive, actor_id, data, size, set_field_5c);
+  void init(ObjectBankArchive* obj_bank_archive, u32 actor_id, ResArchiveHeader* data, int size, char set_field_5c) {
+    return rnd::util::GetPointer<void(ObjectBankArchive*, u32, ResArchiveHeader*, int, char)>(0x1F57DC)(
+        obj_bank_archive, actor_id, data, size, set_field_5c);
   }
   void* getCmbFile(ObjectBankArchive* obj_bank_archive, u32 cmb_file_index, u32 archive_type) {
-    return rnd::util::GetPointer<void*(ObjectBankArchive*, u32, u32)>(0x1F5C00)(
-        obj_bank_archive, cmb_file_index, archive_type);
+    return rnd::util::GetPointer<void*(ObjectBankArchive*, u32, u32)>(0x1F5C00)(obj_bank_archive, cmb_file_index,
+                                                                                archive_type);
   }
   void free(ObjectBankArchive* obj_bank_archive) {
     return rnd::util::GetPointer<void(ObjectBankArchive*)>(0x1E477C)(obj_bank_archive);

--- a/code/source/game/player.cpp
+++ b/code/source/game/player.cpp
@@ -10,8 +10,7 @@ namespace game::act {
 
   static void PlayerChangeStateToStill(Player* player, GlobalContext* gctx) {
     constexpr float speed_maybe = -6.0;
-    rnd::util::GetPointer<void(Player*, GlobalContext*, float)>(0x1E6500)(player, gctx,
-                                                                          speed_maybe);
+    rnd::util::GetPointer<void(Player*, GlobalContext*, float)>(0x1E6500)(player, gctx, speed_maybe);
   }
 
   FormParam& GetFormParam(FormParamIndex idx) {
@@ -37,12 +36,11 @@ namespace game::act {
 
     if (active_form == Player::Form::Deku) {
       // Playing the Honey and Darling shooting minigame as Deku Link.
-      info.can_use = cdata.save.player.magic >= 2 ||
-                     ((cdata.save.anonymous_72 & 1) && gctx->scene == SceneId::HoneyAndDarling);
+      info.can_use =
+          cdata.save.player.magic >= 2 || ((cdata.save.anonymous_72 & 1) && gctx->scene == SceneId::HoneyAndDarling);
     } else {
-      info.can_use = flags3.IsSet(Flag3::DekuStuffMaybe) ||
-                     (cdata.field_3696 == 1 && gctx->hud_state.field_244) || gctx->field_C531 ||
-                     rnd::util::GetPointer<bool(ItemId)>(0x224EF8)(info.item_id);
+      info.can_use = flags3.IsSet(Flag3::DekuStuffMaybe) || (cdata.field_3696 == 1 && gctx->hud_state.field_244) ||
+                     gctx->field_C531 || rnd::util::GetPointer<bool(ItemId)>(0x224EF8)(info.item_id);
     }
 
     return info;
@@ -82,9 +80,9 @@ namespace game::act {
       statue->timer = 0;
     } else if (player->timer > 5) {
       auto* statue = gctx->elegy_statues[u8(player->active_form)];
-      const bool statue_ready = !statue || (statue->pos.pos.x == player->pos.pos.x &&
-                                            statue->pos.pos.y == player->pos.pos.y &&
-                                            statue->pos.pos.z == player->pos.pos.z);
+      const bool statue_ready =
+          !statue || (statue->pos.pos.x == player->pos.pos.x && statue->pos.pos.y == player->pos.pos.y &&
+                      statue->pos.pos.z == player->pos.pos.z);
       if (player->timer > 135 || statue_ready) {
         gctx->ocarina_state = OcarinaState::StoppedPlaying;
         PlayerChangeStateToStill(player, gctx);

--- a/code/source/game/sound.cpp
+++ b/code/source/game/sound.cpp
@@ -26,18 +26,16 @@ namespace game::sound {
   }
 
   StreamId GetCurrentStreamId(StreamPlayer player) {
-    return rnd::util::GetPointer<StreamId(StreamMgr&, StreamPlayer)>(0x1E1194)(GetStreamMgr(),
-                                                                               player);
+    return rnd::util::GetPointer<StreamId(StreamMgr&, StreamPlayer)>(0x1E1194)(GetStreamMgr(), player);
   }
 
   bool PlayStream(StreamId id, StreamPlayer player) {
-    return rnd::util::GetPointer<bool(StreamMgr&, StreamId, StreamPlayer, u32)>(0x239228)(
-        GetStreamMgr(), id, player, 0xffffffff);
+    return rnd::util::GetPointer<bool(StreamMgr&, StreamId, StreamPlayer, u32)>(0x239228)(GetStreamMgr(), id, player,
+                                                                                          0xffffffff);
   }
 
   void ControlStream(StreamPlayer player, int a, int b) {
-    rnd::util::GetPointer<void(StreamMgr&, StreamPlayer, int, int)>(0x1DC2F0)(GetStreamMgr(),
-                                                                              player, a, b);
+    rnd::util::GetPointer<void(StreamMgr&, StreamPlayer, int, int)>(0x1DC2F0)(GetStreamMgr(), player, a, b);
   }
 
   void ControlEnv(int index) {

--- a/code/source/main.cpp
+++ b/code/source/main.cpp
@@ -65,7 +65,8 @@ namespace rnd {
       // Before calling let's be absolutely sure we have the player available.
       if (link) {
         game::SaveData& saveData = game::GetCommonData().save;
-        util::Print("%s: Address is %p and value is %u\n", __func__, &saveData.player.magic_acquired, saveData.player.magic_acquired);
+        util::Print("%s: Address is %p and value is %u\n", __func__, &saveData.player.magic_acquired,
+                    saveData.player.magic_acquired);
         saveData.player.magic_acquired = 1;
         return;
       }

--- a/code/source/main.cpp
+++ b/code/source/main.cpp
@@ -64,6 +64,9 @@ namespace rnd {
       game::act::Player* link = context.gctx->GetPlayerActor();
       // Before calling let's be absolutely sure we have the player available.
       if (link) {
+        game::SaveData& saveData = game::GetCommonData().save;
+        util::Print("%s: Address is %p and value is %u\n", __func__, &saveData.player.magic_acquired, saveData.player.magic_acquired);
+        saveData.player.magic_acquired = 1;
         return;
       }
     }

--- a/code/source/rnd/extdata.cpp
+++ b/code/source/rnd/extdata.cpp
@@ -41,9 +41,8 @@ namespace rnd {
 
     FS_Path iconPath = {PATH_BINARY, sizeof(iconLowPath), &iconLowPath};
     // Open icon
-    if (R_FAILED(res =
-                     FSUSER_OpenFileDirectly(&icnHandle, ARCHIVE_ROMFS, fsMakePath(PATH_EMPTY, ""),
-                                             iconPath, FS_OPEN_READ, 0))) {
+    if (R_FAILED(res = FSUSER_OpenFileDirectly(&icnHandle, ARCHIVE_ROMFS, fsMakePath(PATH_EMPTY, ""), iconPath,
+                                               FS_OPEN_READ, 0))) {
 #if defined ENABLE_DEBUG || defined DEBUG_PRINT
       rnd::util::Print("%s: Opened icon FAILED.\n", __func__);
 #endif
@@ -150,8 +149,7 @@ namespace rnd {
     return bytes_read;
   }
 
-  u32 extDataReadFileDirectly(FS_Archive fsa, char* filename, void* buf_out, u64 offset,
-                              u32 count) {
+  u32 extDataReadFileDirectly(FS_Archive fsa, char* filename, void* buf_out, u64 offset, u32 count) {
     Result res;
     Handle handle = extInitFileHandle();
     u32 bytes_read;
@@ -172,8 +170,7 @@ namespace rnd {
     Result res;
     u32 bytes_written;
 
-    if (R_FAILED(
-            res = FSFILE_Write(handle, &bytes_written, offset, buf, count, FS_WRITE_UPDATE_TIME))) {
+    if (R_FAILED(res = FSFILE_Write(handle, &bytes_written, offset, buf, count, FS_WRITE_UPDATE_TIME))) {
       bytes_written = res;
     }
 
@@ -220,8 +217,7 @@ namespace rnd {
       }
     }
 
-    if (R_FAILED(
-            res = FSFILE_Write(handle, &bytes_written, offset, buf, count, FS_WRITE_UPDATE_TIME))) {
+    if (R_FAILED(res = FSFILE_Write(handle, &bytes_written, offset, buf, count, FS_WRITE_UPDATE_TIME))) {
       res = -3;
       bytes_written = res;
     }

--- a/code/source/rnd/icetrap.cpp
+++ b/code/source/rnd/icetrap.cpp
@@ -11,13 +11,12 @@ namespace rnd {
   void IceTrap_Give() {
     game::GlobalContext* gctx = GetContext().gctx;
     game::act::Player* link = gctx->GetPlayerActor();
-    if (link->flags1.IsOneSet(game::act::Player::Flag1::FreezeLink,
-                              game::act::Player::Flag1::FreezeWorld)) {
+    if (link->flags1.IsOneSet(game::act::Player::Flag1::FreezeLink, game::act::Player::Flag1::FreezeWorld)) {
       return;
     } else if (gPendingFreezes && link->timer == 0) {
       gPendingFreezes -= 1;
-      rnd::util::GetPointer<void(game::GlobalContext*, game::act::Player*, int, int16_t, char,
-                                 int)>(0x239794)(gctx, link, 3, 1, 0, 1);
+      rnd::util::GetPointer<void(game::GlobalContext*, game::act::Player*, int, int16_t, char, int)>(0x239794)(
+          gctx, link, 3, 1, 0, 1);
     }
     return;
   }

--- a/code/source/rnd/item_effect.cpp
+++ b/code/source/rnd/item_effect.cpp
@@ -122,10 +122,6 @@ namespace rnd {
   }
 
   void ItemEffect_GiveProgressiveMagic(game::CommonData* comData, s16 arg1, s16 arg2) {
-#if defined ENABLE_DEBUG || DEBUG_PRINT
-    util::Print("%s: Current magic acquired == %u\n", __func__,
-                comData->save.player.magic_acquired);
-#endif
     if (comData->save.player.magic_acquired != 0) {
       ItemEffect_GiveDoubleMagic(comData, arg1, arg2);
     } else {

--- a/code/source/rnd/item_effect.cpp
+++ b/code/source/rnd/item_effect.cpp
@@ -11,10 +11,8 @@ namespace rnd {
 
   void ItemEffect_FullHeal(game::CommonData* comData, s16 arg1, s16 arg) {
     // With the No Health Refills option on, store-bought health upgrades do not heal the player
-    if ((gSettingsContext.heartDropRefill !=
-         (u8)HeartDropRefillSetting::HEARTDROPREFILL_NOREFILL) &&
-        (gSettingsContext.heartDropRefill !=
-         (u8)HeartDropRefillSetting::HEARTDROPREFILL_NODROPREFILL)) {
+    if ((gSettingsContext.heartDropRefill != (u8)HeartDropRefillSetting::HEARTDROPREFILL_NOREFILL) &&
+        (gSettingsContext.heartDropRefill != (u8)HeartDropRefillSetting::HEARTDROPREFILL_NODROPREFILL)) {
       comData->health_accumulator = 20 * 0x10;
     }
     return;
@@ -32,8 +30,7 @@ namespace rnd {
     if (comData->save.equipment.sword_shield.sword > game::SwordType::KokiriSword) {
       return;
     }
-    comData->save.equipment.sword_shield.sword =
-        game::SwordType::KokiriSword;  // Set sword to kokiri.
+    comData->save.equipment.sword_shield.sword = game::SwordType::KokiriSword;  // Set sword to kokiri.
   }
 
   void ItemEffect_GiveRazorSword(game::CommonData* comData, s16 arg1, s16 arg2) {
@@ -41,14 +38,12 @@ namespace rnd {
     if (comData->save.equipment.sword_shield.sword > game::SwordType::RazorSword) {
       return;
     }
-    comData->save.player.razor_sword_hp = 100;  // Set to 100 hits. Maybe randomize?
-    comData->save.equipment.sword_shield.sword =
-        game::SwordType::RazorSword;  // Set sword to razor.
+    comData->save.player.razor_sword_hp = 100;                                 // Set to 100 hits. Maybe randomize?
+    comData->save.equipment.sword_shield.sword = game::SwordType::RazorSword;  // Set sword to razor.
   }
 
   void ItemEffect_GiveGildedSword(game::CommonData* comData, s16 arg1, s16 arg2) {
-    comData->save.equipment.sword_shield.sword =
-        game::SwordType::GildedSword;  // Set sword to gilded.
+    comData->save.equipment.sword_shield.sword = game::SwordType::GildedSword;  // Set sword to gilded.
   }
 
   void ItemEffect_GiveBottle(game::CommonData* comData, s16 bottleItemId, s16 arg2) {
@@ -68,27 +63,19 @@ namespace rnd {
     s8 keys;
     switch (dungeonId) {
     case 0:
-      keys = comData->save.inventory.woodfall_temple_keys < 0 ?
-                 0 :
-                 comData->save.inventory.woodfall_temple_keys;
+      keys = comData->save.inventory.woodfall_temple_keys < 0 ? 0 : comData->save.inventory.woodfall_temple_keys;
       comData->save.inventory.woodfall_temple_keys = keys + 1;
       break;
     case 1:
-      keys = comData->save.inventory.snowhead_temple_keys < 0 ?
-                 0 :
-                 comData->save.inventory.snowhead_temple_keys;
+      keys = comData->save.inventory.snowhead_temple_keys < 0 ? 0 : comData->save.inventory.snowhead_temple_keys;
       comData->save.inventory.snowhead_temple_keys = keys + 1;
       break;
     case 2:
-      keys = comData->save.inventory.great_bay_temple_keys < 0 ?
-                 0 :
-                 comData->save.inventory.great_bay_temple_keys;
+      keys = comData->save.inventory.great_bay_temple_keys < 0 ? 0 : comData->save.inventory.great_bay_temple_keys;
       comData->save.inventory.great_bay_temple_keys = keys + 1;
       break;
     case 3:
-      keys = comData->save.inventory.stone_tower_temple_keys < 0 ?
-                 0 :
-                 comData->save.inventory.stone_tower_temple_keys;
+      keys = comData->save.inventory.stone_tower_temple_keys < 0 ? 0 : comData->save.inventory.stone_tower_temple_keys;
       comData->save.inventory.stone_tower_temple_keys = keys + 1;
       break;
     default:
@@ -136,10 +123,8 @@ namespace rnd {
 
   void ItemEffect_GiveDoubleDefense(game::CommonData* comData, s16 arg1, s16 arg2) {
     comData->save.player.double_defense = 1;
-    if ((gSettingsContext.heartDropRefill !=
-         (u8)HeartDropRefillSetting::HEARTDROPREFILL_NOREFILL) &&
-        (gSettingsContext.heartDropRefill !=
-         (u8)HeartDropRefillSetting::HEARTDROPREFILL_NODROPREFILL)) {
+    if ((gSettingsContext.heartDropRefill != (u8)HeartDropRefillSetting::HEARTDROPREFILL_NOREFILL) &&
+        (gSettingsContext.heartDropRefill != (u8)HeartDropRefillSetting::HEARTDROPREFILL_NODROPREFILL)) {
       comData->health_accumulator = 20 * 0x10;
     }
   }
@@ -326,12 +311,10 @@ namespace rnd {
   void ItemEffect_GiveSkulltula(game::CommonData* comData, s16 whichHouse, s16 arg2) {
     switch (whichHouse) {
     case 0:
-      comData->save.skulltulas_collected.swamp_count =
-          comData->save.skulltulas_collected.swamp_count + 1;
+      comData->save.skulltulas_collected.swamp_count = comData->save.skulltulas_collected.swamp_count + 1;
       break;
     case 1:
-      comData->save.skulltulas_collected.ocean_count =
-          comData->save.skulltulas_collected.ocean_count + 1;
+      comData->save.skulltulas_collected.ocean_count = comData->save.skulltulas_collected.ocean_count + 1;
       break;
     default:
       break;

--- a/code/source/rnd/item_override.cpp
+++ b/code/source/rnd/item_override.cpp
@@ -56,8 +56,7 @@ namespace rnd {
     rDummyActor->parent_actor = NULL;
   }
 
-  static ItemOverride_Key ItemOverride_GetSearchKey(game::act::Actor* actor, u16 scene,
-                                                    s16 getItemId) {
+  static ItemOverride_Key ItemOverride_GetSearchKey(game::act::Actor* actor, u16 scene, s16 getItemId) {
     game::CommonData& cdata = game::GetCommonData();
     ItemOverride_Key retKey;
     retKey.all = 0;
@@ -72,9 +71,10 @@ namespace rnd {
       // }
       retKey.scene = scene;
       retKey.type = ItemOverride_Type::OVR_CHEST;
-// #if defined ENABLE_DEBUG || defined DEBUG_PRINT
-//       util::Print("%s Our flag is actually %#06x and & 0x1F is %#06x\n", __func__, actor->params, actor->params & 0x1F);
-// #endif
+      // #if defined ENABLE_DEBUG || defined DEBUG_PRINT
+      //       util::Print("%s Our flag is actually %#06x and & 0x1F is %#06x\n", __func__,
+      //       actor->params, actor->params & 0x1F);
+      // #endif
       retKey.flag = actor->params & 0x1F;
       return retKey;
     } else if (actor->actor_type == game::act::Type::Misc) {  // Heart pieces are misc apparently
@@ -154,8 +154,7 @@ namespace rnd {
     rActiveItemActionId = itemRow->itemId;
     rActiveItemTextId = itemRow->textId;
     rActiveItemObjectId = itemRow->objectId;
-    rActiveItemGraphicId =
-        looksLikeItemId ? ItemTable_GetItemRow(looksLikeItemId)->graphicId : itemRow->graphicId;
+    rActiveItemGraphicId = looksLikeItemId ? ItemTable_GetItemRow(looksLikeItemId)->graphicId : itemRow->graphicId;
     rActiveItemFastChest = (u32)itemRow->chestType & 0x01;
   }
 
@@ -396,16 +395,16 @@ namespace rnd {
       gExtSaveData.grannyGaveReward++;
 #if defined ENABLE_DEBUG || defined DEBUG_PRINT
       rnd::util::Print("%s: Granny give reward is currently %u, should be incremented.\n", __func__,
-#endif
                        gExtSaveData.grannyGaveReward);
+#endif
     } else if (actorId == game::act::Id::NpcEnBjt) {
       getItemId = incomingNegative ? -0x01 : 0x01;
     } else if (actorId == game::act::Id::NpcSwampPhotographer) {
       getItemId = incomingNegative ? -0xBA : 0xBA;
     } else if (actorId == game::act::Id::NpcInvisibleGuard) {
 #if defined ENABLE_DEBUG || defined DEBUG_PRINT
-      rnd::util::Print("%s: Invisilbe Stone Man give reward is currently %u, incrementing.\n",
-                       __func__, gExtSaveData.stoneMaskReward);
+      rnd::util::Print("%s: Invisilbe Stone Man give reward is currently %u, incrementing.\n", __func__,
+                       gExtSaveData.stoneMaskReward);
 #endif
       if (gExtSaveData.stoneMaskReward > 0) {
         getItemId = incomingNegative ? -0xBA : 0xBA;
@@ -431,15 +430,15 @@ namespace rnd {
     if (rActiveItemRow != NULL) {
       if (rActiveItemOverride.key.type == ItemOverride_Type::OVR_CHEST) {
 #if defined ENABLE_DEBUG || defined DEBUG_PRINT
-        rnd::util::Print("%s: Item Override is the chest right now. Our activeItemRow itemId is %06x\n", __func__, rActiveItemRow->itemId);
+        rnd::util::Print("%s: Item Override is the chest right now. Our activeItemRow itemId is %06x\n", __func__,
+                         rActiveItemRow->itemId);
 #endif
         if (rActiveItemRow->itemId < 0x28 && rActiveItemRow->itemId > 0x30) {
 #if defined ENABLE_DEBUG || defined DEBUG_PRINT
-            rnd::util::Print("%s:\n", __func__);
+          rnd::util::Print("%s:\n", __func__);
 #endif
           gExtSaveData.chestRewarded[rActiveItemOverride.key.scene][rActiveItemOverride.key.flag] = 1;
         }
-          
       }
       game::GlobalContext* gctx = rnd::GetContext().gctx;
       // int retVal;
@@ -449,21 +448,20 @@ namespace rnd {
       gctx->ShowMessage(textId, actor);
       // Get_Item_Handler. Don't give ice traps, since it may cause UB.
       if (itemId != (u8)game::ItemId::X82) {
-        rnd::util::GetPointer<int(game::GlobalContext*, game::ItemId)>(0x233BEC)(
-            gctx, (game::ItemId)itemId);
+        rnd::util::GetPointer<int(game::GlobalContext*, game::ItemId)>(0x233BEC)(gctx, (game::ItemId)itemId);
       }
       ItemOverride_AfterItemReceived();
     }
   }
 
-  void ItemOverride_GetItem(game::GlobalContext* gctx, game::act::Actor* fromActor,
-                            game::act::Player* player, s16 incomingGetItemId) {
+  void ItemOverride_GetItem(game::GlobalContext* gctx, game::act::Actor* fromActor, game::act::Player* player,
+                            s16 incomingGetItemId) {
     ItemOverride override = {0};
     s32 incomingNegative = incomingGetItemId < 0;
     if (fromActor != NULL && incomingGetItemId != 0) {
-// #if defined ENABLE_DEBUG || DEBUG_PRINT
-//       rnd::util::Print("%s: Our actor ID is %#06x\n", __func__, fromActor->id);
-// #endif
+      // #if defined ENABLE_DEBUG || DEBUG_PRINT
+      //       rnd::util::Print("%s: Our actor ID is %#06x\n", __func__, fromActor->id);
+      // #endif
       s16 getItemId = ItemOverride_CheckNpc(fromActor->id, incomingGetItemId, incomingNegative);
       override = ItemOverride_Lookup(fromActor, (u16)gctx->scene, getItemId);
     }
@@ -494,8 +492,7 @@ namespace rnd {
     return;
   }
 
-  void ItemOverride_GetFairyRewardItem(game::GlobalContext* gctx, game::act::Actor* fromActor,
-                                       s16 incomingItemId) {
+  void ItemOverride_GetFairyRewardItem(game::GlobalContext* gctx, game::act::Actor* fromActor, s16 incomingItemId) {
     ItemOverride override = {0};
     s32 incomingNegative = incomingItemId < 0;
     if (fromActor != NULL && incomingItemId != 0) {
@@ -522,7 +519,7 @@ namespace rnd {
       rActiveItemRow->effectArg1 = override.key.all >> 16;
       rActiveItemRow->effectArg2 = override.key.all & 0xFFFF;
     }
-    
+
     if (game::GetCommonData().save.player.anonymous_18 == 0) {
       game::GetCommonData().save.player.anonymous_18 = 1;
       // Since we're in control here, use the GetItemId and not the item id.

--- a/code/source/rnd/item_override.cpp
+++ b/code/source/rnd/item_override.cpp
@@ -72,6 +72,9 @@ namespace rnd {
       // }
       retKey.scene = scene;
       retKey.type = ItemOverride_Type::OVR_CHEST;
+#if defined ENABLE_DEBUG || defined DEBUG_PRINT
+      util::Print("%s Our flag is actually %u and & 0x1F is %u\n", __func__, actor->params, actor->params & 0x1F);
+#endif
       retKey.flag = actor->params & 0x1F;
       return retKey;
     } else if (actor->actor_type == game::act::Type::Misc) {  // Heart pieces are misc apparently
@@ -264,7 +267,9 @@ namespace rnd {
         return;
       }
       if (rDummyActor->parent_actor == NULL) {
+#if defined ENABLE_DEBUG || defined DEBUG_PRINT
         rnd::util::Print("%s: Trying to pop the pending item.\n", __func__);
+#endif
         ItemOverride_Activate(override);
         player->grabbable_actor = rDummyActor;
         player->get_item_id = rActiveItemRow->baseItemId;
@@ -389,7 +394,9 @@ namespace rnd {
         getItemId = incomingNegative ? -0xBA : 0xBA;
       }
       gExtSaveData.grannyGaveReward++;
+#if defined ENABLE_DEBUG || defined DEBUG_PRINT
       rnd::util::Print("%s: Granny give reward is currently %u, should be incremented.\n", __func__,
+#endif
                        gExtSaveData.grannyGaveReward);
     } else if (actorId == game::act::Id::NpcEnBjt) {
       getItemId = incomingNegative ? -0x01 : 0x01;
@@ -432,9 +439,6 @@ namespace rnd {
       if (itemId != (u8)game::ItemId::X82) {
         rnd::util::GetPointer<int(game::GlobalContext*, game::ItemId)>(0x233BEC)(
             gctx, (game::ItemId)itemId);
-        // rnd::util::Print("%s: Talk Actor ID is %#06x\n", __func__, actor->grabbable_actor->id);
-        /*rnd::util::GetPointer<void(game::GlobalContext*, int, int)>(0x2204ec)(
-            gctx, 100, -1);*/
       }
       ItemOverride_AfterItemReceived();
     }
@@ -467,7 +471,9 @@ namespace rnd {
     }
 
     player->get_item_id = incomingNegative ? -baseItemId : baseItemId;
-    rStoredBomberNoteTextId = rActiveItemRow->textId;
+    if (fromActor->actor_type != game::act::Type::Chest) {
+      rStoredBomberNoteTextId = rActiveItemRow->textId;
+    }
     return;
   }
 
@@ -492,7 +498,9 @@ namespace rnd {
     }
 
     ItemOverride_PushPendingOverride(override);
+#if defined ENABLE_DEBUG || defined DEBUG_PRINT
     rnd::util::Print("%s: Trying to pop the pending item.\n", __func__);
+#endif
     // s8 baseItemId = rActiveItemRow->textId;
     if (override.value.getItemId == 0x12) {
       rActiveItemRow->effectArg1 = override.key.all >> 16;

--- a/code/source/rnd/item_override.cpp
+++ b/code/source/rnd/item_override.cpp
@@ -39,8 +39,8 @@ namespace rnd {
     rItemOverrides[0].value.looksLikeItemId = 0x26;
     rItemOverrides[1].key.scene = 0x6C;
     rItemOverrides[1].key.type = ItemOverride_Type::OVR_CHEST;
-    rItemOverrides[1].value.getItemId = 0x49;
-    rItemOverrides[1].value.looksLikeItemId = 0xB3;
+    rItemOverrides[1].value.getItemId = 0x9A;
+    rItemOverrides[1].value.looksLikeItemId = 0x2C;
     rItemOverrides[2].key.scene = 0x12;
     rItemOverrides[2].key.type = ItemOverride_Type::OVR_COLLECTABLE;
     rItemOverrides[2].value.getItemId = 0x37;
@@ -431,9 +431,15 @@ namespace rnd {
     if (rActiveItemRow != NULL) {
       if (rActiveItemOverride.key.type == ItemOverride_Type::OVR_CHEST) {
 #if defined ENABLE_DEBUG || defined DEBUG_PRINT
-        rnd::util::Print("%s: Item Override is the chest right now.\n", __func__);
+        rnd::util::Print("%s: Item Override is the chest right now. Our activeItemRow itemId is %06x\n", __func__, rActiveItemRow->itemId);
 #endif
-        gExtSaveData.chestRewarded[rActiveItemOverride.key.scene][rActiveItemOverride.key.flag] = 1;
+        if (rActiveItemRow->itemId < 0x28 && rActiveItemRow->itemId > 0x30) {
+#if defined ENABLE_DEBUG || defined DEBUG_PRINT
+            rnd::util::Print("%s:\n", __func__);
+#endif
+          gExtSaveData.chestRewarded[rActiveItemOverride.key.scene][rActiveItemOverride.key.flag] = 1;
+        }
+          
       }
       game::GlobalContext* gctx = rnd::GetContext().gctx;
       // int retVal;

--- a/code/source/rnd/item_override.cpp
+++ b/code/source/rnd/item_override.cpp
@@ -479,6 +479,9 @@ namespace rnd {
 
   void ItemOverride_GetFairyRewardItem(game::GlobalContext* gctx, game::act::Actor* fromActor,
                                        s16 incomingItemId) {
+    if (gExtSaveData.gaveFairyMaskReward == 1) {
+      return;
+    }
     ItemOverride override = {0};
     s32 incomingNegative = incomingItemId < 0;
     if (fromActor != NULL && incomingItemId != 0) {
@@ -506,7 +509,7 @@ namespace rnd {
       rActiveItemRow->effectArg1 = override.key.all >> 16;
       rActiveItemRow->effectArg2 = override.key.all & 0xFFFF;
     }
-
+    gExtSaveData.gaveFairyMaskReward = 1;
     // rStoredBomberNoteTextId = rActiveItemRow->textId;
     return;
   }

--- a/code/source/rnd/item_table.cpp
+++ b/code/source/rnd/item_table.cpp
@@ -9,1097 +9,948 @@
 
 namespace rnd {
 
-#define ITEM_ROW(baseItemId_, chestType_, itemId_, textId_, objectId_, objectModelIdx_,            \
-                 cmabIndex_, objectModelIdx2_, cmabIndex2_, special_, graphicId_, upgrade_,        \
-                 effect_, effectArg1_, effectArg2_)                                                \
-  {                                                                                                \
-    .baseItemId = baseItemId_, .chestType = chestType_, .itemId = itemId_, .textId = textId_,      \
-    .objectId = objectId_, .objectModelIdx = objectModelIdx_, .cmabIndex = cmabIndex_,             \
-    .objectModelIdx2 = objectModelIdx2_, .cmabIndex2 = cmabIndex2_, .special = special_,           \
-    .graphicId = graphicId_, .upgrade = upgrade_, .effect = effect_, .effectArg1 = effectArg1_,    \
-    .effectArg2 = effectArg2_                                                                      \
+#define ITEM_ROW(baseItemId_, chestType_, itemId_, textId_, objectId_, objectModelIdx_, cmabIndex_, objectModelIdx2_,  \
+                 cmabIndex2_, special_, graphicId_, upgrade_, effect_, effectArg1_, effectArg2_)                       \
+  {                                                                                                                    \
+    .baseItemId = baseItemId_, .chestType = chestType_, .itemId = itemId_, .textId = textId_, .objectId = objectId_,   \
+    .objectModelIdx = objectModelIdx_, .cmabIndex = cmabIndex_, .objectModelIdx2 = objectModelIdx2_,                   \
+    .cmabIndex2 = cmabIndex2_, .special = special_, .graphicId = graphicId_, .upgrade = upgrade_, .effect = effect_,   \
+    .effectArg1 = effectArg1_, .effectArg2 = effectArg2_                                                               \
   }
 
   ItemRow rItemTable[] = {
-      [0x00] =
-          ITEM_ROW((u32)GetItemID::GI_NONE, ChestType::WOODEN_SMALL, 0xFF, 0x00C4, 0x0000, 0x00,
-                   (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_NONE,
-                   (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1,
-                   (s16)-1),  // None Item - So we don't have to do GetItemId-1 everywhere.
+      [0x00] = ITEM_ROW((u32)GetItemID::GI_NONE, ChestType::WOODEN_SMALL, 0xFF, 0x00C4, 0x0000, 0x00, (s8)0xFF,
+                        (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_NONE,
+                        (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1,
+                        (s16)-1),  // None Item - So we don't have to do GetItemId-1 everywhere.
 
-      [0x01] = ITEM_ROW((u32)GetItemID::GI_RUPEE_BLUE, ChestType::WOODEN_SMALL,
-                        (u8)game::ItemId::OneRupee, 0x00C4, 0x013F, (s8)0xFF, (s8)0xFF, (s8)0xFF,
-                        (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_GREEN_RUPEE,
-                        (rnd::upgradeFunc)ItemUpgrade_BombsToRupee, ItemEffect_None, (s16)-1,
-                        (s16)-1),  // Green Rupee
+      [0x01] =
+          ITEM_ROW((u32)GetItemID::GI_RUPEE_BLUE, ChestType::WOODEN_SMALL, (u8)game::ItemId::OneRupee, 0x00C4, 0x013F,
+                   (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_GREEN_RUPEE,
+                   (rnd::upgradeFunc)ItemUpgrade_BombsToRupee, ItemEffect_None, (s16)-1,
+                   (s16)-1),  // Green Rupee
 
-      [0x02] = ITEM_ROW((u32)GetItemID::GI_RUPEE_BLUE, ChestType::WOODEN_SMALL,
-                        (u8)game::ItemId::FiveRupees, 0x0002, 0x013F, (s8)0xFF, (s8)0xFF, (s8)0xFF,
-                        (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_BLUE_RUPEE,
+      [0x02] = ITEM_ROW((u32)GetItemID::GI_RUPEE_BLUE, ChestType::WOODEN_SMALL, (u8)game::ItemId::FiveRupees, 0x0002,
+                        0x013F, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_BLUE_RUPEE,
                         (rnd::upgradeFunc)ItemUpgrade_BombsToRupee, ItemEffect_None, (s16)-1,
                         (s16)-1),  // Blue Rupee
       // BREAKS
-      [0x03] = ITEM_ROW((u32)GetItemID::GI_RUPEE_BLUE, ChestType::WOODEN_SMALL,
-                        (u8)game::ItemId::TenRupees, 0x0003, 0x013F, (s8)0xFF, (s8)0xFF, (s8)0xFF,
-                        (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_RED_RUPEE,
+      [0x03] = ITEM_ROW((u32)GetItemID::GI_RUPEE_BLUE, ChestType::WOODEN_SMALL, (u8)game::ItemId::TenRupees, 0x0003,
+                        0x013F, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_RED_RUPEE,
                         (rnd::upgradeFunc)ItemUpgrade_BombsToRupee, ItemEffect_None, (s16)-1,
                         (s16)-1),  // Ten Rupees
 
-      [0x04] = ITEM_ROW((u32)GetItemID::GI_RUPEE_BLUE, ChestType::WOODEN_SMALL,
-                        (u8)game::ItemId::TwentyRupees, 0x0004, 0x013F, (s8)0xFF, (s8)0xFF,
-                        (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_RED_RUPEE,
+      [0x04] = ITEM_ROW((u32)GetItemID::GI_RUPEE_BLUE, ChestType::WOODEN_SMALL, (u8)game::ItemId::TwentyRupees, 0x0004,
+                        0x013F, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_RED_RUPEE,
                         (rnd::upgradeFunc)ItemUpgrade_BombsToRupee, ItemEffect_None, (s16)-1,
                         (s16)-1),  // Red Rupee
 
-      [0x05] = ITEM_ROW((u32)GetItemID::GI_RUPEE_BLUE, ChestType::WOODEN_SMALL,
-                        (u8)game::ItemId::FiftyRupees, 0x0005, 0x013F, (s8)0xFF, (s8)0xFF, (s8)0xFF,
-                        (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_PURPLE_RUPEE,
-                        (rnd::upgradeFunc)ItemUpgrade_BombsToRupee, ItemEffect_None, (s16)-1,
-                        (s16)-1),  // Purple Rupee
+      [0x05] =
+          ITEM_ROW((u32)GetItemID::GI_RUPEE_BLUE, ChestType::WOODEN_SMALL, (u8)game::ItemId::FiftyRupees, 0x0005,
+                   0x013F, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_PURPLE_RUPEE,
+                   (rnd::upgradeFunc)ItemUpgrade_BombsToRupee, ItemEffect_None, (s16)-1,
+                   (s16)-1),  // Purple Rupee
 
-      [0x06] = ITEM_ROW((u32)GetItemID::GI_RUPEE_BLUE, ChestType::WOODEN_SMALL,
-                        (u8)game::ItemId::OneHundredRupees, 0x0006, 0x013F, (s8)0xFF, (s8)0xFF,
-                        (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_SILVER_RUPEE,
-                        (rnd::upgradeFunc)ItemUpgrade_BombsToRupee, ItemEffect_None, (s16)-1,
-                        (s16)-1),  // Silver Rupee
+      [0x06] =
+          ITEM_ROW((u32)GetItemID::GI_RUPEE_BLUE, ChestType::WOODEN_SMALL, (u8)game::ItemId::OneHundredRupees, 0x0006,
+                   0x013F, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_SILVER_RUPEE,
+                   (rnd::upgradeFunc)ItemUpgrade_BombsToRupee, ItemEffect_None, (s16)-1,
+                   (s16)-1),  // Silver Rupee
 
-      [0x07] = ITEM_ROW((u32)GetItemID::GI_RUPEE_BLUE, ChestType::WOODEN_SMALL,
-                        (u8)game::ItemId::TwoHundredRupees, 0x0007, 0x013F, (s8)0xFF, (s8)0xFF,
-                        (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_GOLD_RUPEE,
-                        (rnd::upgradeFunc)ItemUpgrade_BombsToRupee, ItemEffect_None, (s16)-1,
-                        (s16)-1),  // Gold Rupee
+      [0x07] =
+          ITEM_ROW((u32)GetItemID::GI_RUPEE_BLUE, ChestType::WOODEN_SMALL, (u8)game::ItemId::TwoHundredRupees, 0x0007,
+                   0x013F, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_GOLD_RUPEE,
+                   (rnd::upgradeFunc)ItemUpgrade_BombsToRupee, ItemEffect_None, (s16)-1,
+                   (s16)-1),  // Gold Rupee
 
       [0x08] =
-          ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::AdultWallet,
-                   0x0008, 0x000A8, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF,
-                   (s32)DrawGraphicItemID::DI_ADULT_WALLET, (rnd::upgradeFunc)ItemUpgrade_None,
-                   ItemEffect_FillWalletUpgrade, (s16)1, (s16)-1),  // Adult Wallet
+          ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::AdultWallet, 0x0008, 0x000A8,
+                   (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_ADULT_WALLET,
+                   (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_FillWalletUpgrade, (s16)1, (s16)-1),  // Adult Wallet
 
       [0x09] =
-          ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::GiantWallet,
-                   0x0009, 0x000A8, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF,
-                   (s32)DrawGraphicItemID::DI_GIANT_WALLET, (rnd::upgradeFunc)ItemUpgrade_None,
-                   ItemEffect_FillWalletUpgrade, (s16)1, (s16)-1),  // Giant Wallet
+          ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::GiantWallet, 0x0009, 0x000A8,
+                   (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_GIANT_WALLET,
+                   (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_FillWalletUpgrade, (s16)1, (s16)-1),  // Giant Wallet
 
-      [0x0A] = ITEM_ROW((u32)GetItemID::GI_RUPEE_BLUE, ChestType::WOODEN_SMALL,
-                        (u8)game::ItemId::RecoveryHeart, 0x000A, 0x00090, (s8)0xFF, (s8)0xFF,
-                        (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_RECOVERY_HEART,
-                        (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1,
-                        (s16)-1),  // Recovery Heart
+      [0x0A] =
+          ITEM_ROW((u32)GetItemID::GI_RUPEE_BLUE, ChestType::WOODEN_SMALL, (u8)game::ItemId::RecoveryHeart, 0x000A,
+                   0x00090, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_RECOVERY_HEART,
+                   (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1,
+                   (s16)-1),  // Recovery Heart
 
-      [0x0B] = ITEM_ROW((u32)GetItemID::GI_RUPEE_BLUE, ChestType::WOODEN_SMALL,
-                        (u8)game::ItemId::RecoveryHeart, 0x000B, 0x00090, (s8)0xFF, (s8)0xFF,
-                        (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_RECOVERY_HEART,
-                        (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1,
-                        (s16)-1),  // Recovery Heart
+      [0x0B] =
+          ITEM_ROW((u32)GetItemID::GI_RUPEE_BLUE, ChestType::WOODEN_SMALL, (u8)game::ItemId::RecoveryHeart, 0x000B,
+                   0x00090, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_RECOVERY_HEART,
+                   (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1,
+                   (s16)-1),  // Recovery Heart
 
-      [0x0C] = ITEM_ROW((u32)GetItemID::GI_RUPEE_BLUE, ChestType::WOODEN_SMALL,
-                        (u8)game::ItemId::PieceOfHeartAgain, 0x000C, 0x00096, (s8)0xFF, (s8)0xFF,
-                        (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_HEART_PIECE,
-                        (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1,
-                        (s16)-1),  // Piece of Heart
+      [0x0C] =
+          ITEM_ROW((u32)GetItemID::GI_RUPEE_BLUE, ChestType::WOODEN_SMALL, (u8)game::ItemId::PieceOfHeartAgain, 0x000C,
+                   0x00096, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_HEART_PIECE,
+                   (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1,
+                   (s16)-1),  // Piece of Heart
 
-      [0x0D] = ITEM_ROW((u32)GetItemID::GI_RUPEE_BLUE, ChestType::WOODEN_BIG,
-                        (u8)game::ItemId::HeartContainer, 0x000D, 0x00096, (s8)0xFF, (s8)0xFF,
-                        (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_HEART_CONTAINER,
-                        (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1,
+      [0x0D] = ITEM_ROW((u32)GetItemID::GI_RUPEE_BLUE, ChestType::WOODEN_BIG, (u8)game::ItemId::HeartContainer, 0x000D,
+                        0x00096, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF,
+                        (s32)DrawGraphicItemID::DI_HEART_CONTAINER, (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None,
+                        (s16)-1,
                         (s16)-1),  // Heart Container
 
-      [0x0E] =
-          ITEM_ROW((u32)GetItemID::GI_RUPEE_BLUE, ChestType::WOODEN_SMALL,
-                   (u8)game::ItemId::SmallMagicAccumulator, 0x00C8, 0x000A4, (s8)0xFF, (s8)0xFF,
-                   (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_SMALL_MAGIC_JAR,
-                   (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1,
-                   (s16)-1),  // Small Magic Jar
+      [0x0E] = ITEM_ROW((u32)GetItemID::GI_RUPEE_BLUE, ChestType::WOODEN_SMALL, (u8)game::ItemId::SmallMagicAccumulator,
+                        0x00C8, 0x000A4, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF,
+                        (s32)DrawGraphicItemID::DI_SMALL_MAGIC_JAR, (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None,
+                        (s16)-1,
+                        (s16)-1),  // Small Magic Jar
 
-      [0x0F] = ITEM_ROW((u32)GetItemID::GI_RUPEE_BLUE, ChestType::WOODEN_SMALL,
-                        (u8)game::ItemId::BigMagicAccumulator, 0x000CC, 0x000A4, (s8)0xFF, (s8)0xFF,
-                        (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_BIG_MAGIC_JAR,
-                        (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1,
+      [0x0F] = ITEM_ROW((u32)GetItemID::GI_RUPEE_BLUE, ChestType::WOODEN_SMALL, (u8)game::ItemId::BigMagicAccumulator,
+                        0x000CC, 0x000A4, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF,
+                        (s32)DrawGraphicItemID::DI_BIG_MAGIC_JAR, (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None,
+                        (s16)-1,
                         (s16)-1),  // Big Magic Jar
 
-      [0x10] = ITEM_ROW((u32)GetItemID::GI_RUPEE_BLUE, ChestType::WOODEN_SMALL,
-                        (u8)game::ItemId::RecoveryHeart, 0x0010, 0x00090, (s8)0xFF, (s8)0xFF,
-                        (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_RECOVERY_HEART,
-                        (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1,
-                        (s16)-1),  // Recovery Heart - Broken Text
+      [0x10] =
+          ITEM_ROW((u32)GetItemID::GI_RUPEE_BLUE, ChestType::WOODEN_SMALL, (u8)game::ItemId::RecoveryHeart, 0x0010,
+                   0x00090, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_RECOVERY_HEART,
+                   (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1,
+                   (s16)-1),  // Recovery Heart - Broken Text
 
-      [0x11] =
-          ITEM_ROW((u32)GetItemID::GI_RUPEE_BLUE, ChestType::WOODEN_SMALL, (u8)game::ItemId::None,
-                   0x0011, 0x00000, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF,
-                   (s32)DrawGraphicItemID::DI_NONE, (rnd::upgradeFunc)ItemUpgrade_None,
-                   ItemEffect_None, (s16)-1, (s16)-1),  // Get Fairy Text
+      [0x11] = ITEM_ROW((u32)GetItemID::GI_RUPEE_BLUE, ChestType::WOODEN_SMALL, (u8)game::ItemId::None, 0x0011, 0x00000,
+                        (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_NONE,
+                        (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1, (s16)-1),  // Get Fairy Text
 
-      [0x12] =
-          ITEM_ROW((u32)GetItemID::GI_RUPEE_BLUE, ChestType::WOODEN_SMALL, (u8)game::ItemId::X82,
-                   0x0012, 0x00FF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)0xFFFF,
-                   (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_IceTrap, (s16)-1,
-                   (s16)-1),  // Ice Trap
-                              // Overriding Errornous text + Recovery Heart
-      [0x13] = ITEM_ROW((u32)GetItemID::GI_RUPEE_BLUE, ChestType::WOODEN_SMALL,
-                        (u8)game::ItemId::RecoveryHeart, 0x0013, 0x00090, (s8)0xFF, (s8)0xFF,
-                        (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_RECOVERY_HEART,
-                        (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1,
-                        (s16)-1),  // Recovery Heart - Broken Text
+      [0x12] = ITEM_ROW((u32)GetItemID::GI_RUPEE_BLUE, ChestType::WOODEN_SMALL, (u8)game::ItemId::X82, 0x0012, 0x00FF,
+                        (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)0xFFFF,
+                        (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_IceTrap, (s16)-1,
+                        (s16)-1),  // Ice Trap
+                                   // Overriding Errornous text + Recovery Heart
+      [0x13] =
+          ITEM_ROW((u32)GetItemID::GI_RUPEE_BLUE, ChestType::WOODEN_SMALL, (u8)game::ItemId::RecoveryHeart, 0x0013,
+                   0x00090, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_RECOVERY_HEART,
+                   (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1,
+                   (s16)-1),  // Recovery Heart - Broken Text
 
-      [0x14] =
-          ITEM_ROW((u32)GetItemID::GI_RUPEE_BLUE, ChestType::WOODEN_SMALL, (u8)game::ItemId::Bomb,
-                   0x0014, 0x00A5, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF,
-                   (s32)DrawGraphicItemID::DI_BOMB, (rnd::upgradeFunc)ItemUpgrade_BombsToRupee,
-                   ItemEffect_None, (s16)-1, (s16)-1),  // Bomb (1)
+      [0x14] = ITEM_ROW((u32)GetItemID::GI_RUPEE_BLUE, ChestType::WOODEN_SMALL, (u8)game::ItemId::Bomb, 0x0014, 0x00A5,
+                        (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_BOMB,
+                        (rnd::upgradeFunc)ItemUpgrade_BombsToRupee, ItemEffect_None, (s16)-1, (s16)-1),  // Bomb (1)
 
-      [0x15] = ITEM_ROW((u32)GetItemID::GI_RUPEE_BLUE, ChestType::WOODEN_SMALL,
-                        (u8)game::ItemId::FiveBombs, 0x0015, 0x00A5, (s8)0xFF, (s8)0xFF, (s8)0xFF,
-                        (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_BOMB,
+      [0x15] = ITEM_ROW((u32)GetItemID::GI_RUPEE_BLUE, ChestType::WOODEN_SMALL, (u8)game::ItemId::FiveBombs, 0x0015,
+                        0x00A5, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_BOMB,
                         (rnd::upgradeFunc)ItemUpgrade_BombsToRupee, ItemEffect_None, (s16)-1,
                         (s16)-1),  // Bombs (5)
 
-      [0x16] = ITEM_ROW((u32)GetItemID::GI_RUPEE_BLUE, ChestType::WOODEN_SMALL,
-                        (u8)game::ItemId::TenBombs, 0x0016, 0x000A5, (s8)0xFF, (s8)0xFF, (s8)0xFF,
-                        (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_BOMB,
+      [0x16] = ITEM_ROW((u32)GetItemID::GI_RUPEE_BLUE, ChestType::WOODEN_SMALL, (u8)game::ItemId::TenBombs, 0x0016,
+                        0x000A5, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_BOMB,
                         (rnd::upgradeFunc)ItemUpgrade_BombsToRupee, ItemEffect_None, (s16)-1,
                         (s16)-1),  // Bombs (10)
 
-      [0x17] = ITEM_ROW((u32)GetItemID::GI_RUPEE_BLUE, ChestType::WOODEN_SMALL,
-                        (u8)game::ItemId::TwentyBombs, 0x0017, 0x000A5, (s8)0xFF, (s8)0xFF,
-                        (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_BOMB,
+      [0x17] = ITEM_ROW((u32)GetItemID::GI_RUPEE_BLUE, ChestType::WOODEN_SMALL, (u8)game::ItemId::TwentyBombs, 0x0017,
+                        0x000A5, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_BOMB,
                         (rnd::upgradeFunc)ItemUpgrade_BombsToRupee, ItemEffect_None, (s16)-1,
                         (s16)-1),  // Bombs (20)
 
-      [0x18] = ITEM_ROW((u32)GetItemID::GI_RUPEE_BLUE, ChestType::WOODEN_SMALL,
-                        (u8)game::ItemId::ThirtyBombs, 0x0018, 0x000A5, (s8)0xFF, (s8)0xFF,
-                        (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_BOMB,
+      [0x18] = ITEM_ROW((u32)GetItemID::GI_RUPEE_BLUE, ChestType::WOODEN_SMALL, (u8)game::ItemId::ThirtyBombs, 0x0018,
+                        0x000A5, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_BOMB,
                         (rnd::upgradeFunc)ItemUpgrade_BombsToRupee, ItemEffect_None, (s16)-1,
                         (s16)-1),  // Bombs (30)
 
-      [0x19] = ITEM_ROW((u32)GetItemID::GI_RUPEE_BLUE, ChestType::WOODEN_SMALL,
-                        (u8)game::ItemId::DekuStick, 0x0019, 0x009F, (s8)0xFF, (s8)0xFF, (s8)0xFF,
-                        (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_DEKU_STICK,
+      [0x19] = ITEM_ROW((u32)GetItemID::GI_RUPEE_BLUE, ChestType::WOODEN_SMALL, (u8)game::ItemId::DekuStick, 0x0019,
+                        0x009F, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_DEKU_STICK,
                         (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1,
                         (s16)-1),  // Deku Stick
 
-      [0x1A] = ITEM_ROW((u32)GetItemID::GI_RUPEE_BLUE, ChestType::WOODEN_SMALL,
-                        (u8)game::ItemId::TenBombchus, 0x001A, 0x00B0, (s8)0xFF, (s8)0xFF, (s8)0xFF,
-                        (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_BOMBCHU,
+      [0x1A] = ITEM_ROW((u32)GetItemID::GI_RUPEE_BLUE, ChestType::WOODEN_SMALL, (u8)game::ItemId::TenBombchus, 0x001A,
+                        0x00B0, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_BOMBCHU,
                         (rnd::upgradeFunc)ItemUpgrade_BombsToRupee, ItemEffect_None, (s16)-1,
                         (s16)-1),  // Bombchus (10)
 
-      [0x1B] =
-          ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::BombBag,
-                   0x001B, 0x00098, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF,
-                   (s32)DrawGraphicItemID::DI_BOMB_BAG, (rnd::upgradeFunc)ItemUpgrade_None,
-                   ItemEffect_None, (s16)-1, (s16)-1),  // Bomb Bag
+      [0x1B] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::BombBag, 0x001B, 0x00098,
+                        (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_BOMB_BAG,
+                        (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1, (s16)-1),  // Bomb Bag
 
       [0x1C] =
-          ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::BigBombBag,
-                   0x001C, 0x00098, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF,
-                   (s32)DrawGraphicItemID::DI_BIG_BOMB_BAG, (rnd::upgradeFunc)ItemUpgrade_None,
-                   ItemEffect_GiveUpgrade, (s16)2, (s16)1),  // Big Bomb Bag
+          ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::BigBombBag, 0x001C, 0x00098,
+                   (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_BIG_BOMB_BAG,
+                   (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_GiveUpgrade, (s16)2, (s16)1),  // Big Bomb Bag
 
-      [0x1D] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG,
-                        (u8)game::ItemId::BiggestBombBag, 0x001D, 0x00098, (s8)0xFF, (s8)0xFF,
-                        (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_BIGGEST_BOMB_BAG,
-                        (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_GiveUpgrade, (s16)3,
-                        (s16)1),  // Biggest Bomb Bag
+      [0x1D] =
+          ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::BiggestBombBag, 0x001D, 0x00098,
+                   (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_BIGGEST_BOMB_BAG,
+                   (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_GiveUpgrade, (s16)3,
+                   (s16)1),  // Biggest Bomb Bag
 
-      [0x1E] = ITEM_ROW((u32)GetItemID::GI_RUPEE_BLUE, ChestType::WOODEN_SMALL,
-                        (u8)game::ItemId::TenArrows, 0x001E, 0x000AF, (s8)0xFF, (s8)0xFF, (s8)0xFF,
-                        (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_SINGLE_ARROW,
-                        (rnd::upgradeFunc)ItemUpgrade_ArrowsToRupee, ItemEffect_None, (s16)-1,
-                        (s16)-1),  // Arrows (10)
+      [0x1E] =
+          ITEM_ROW((u32)GetItemID::GI_RUPEE_BLUE, ChestType::WOODEN_SMALL, (u8)game::ItemId::TenArrows, 0x001E, 0x000AF,
+                   (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_SINGLE_ARROW,
+                   (rnd::upgradeFunc)ItemUpgrade_ArrowsToRupee, ItemEffect_None, (s16)-1,
+                   (s16)-1),  // Arrows (10)
 
-      [0x1F] = ITEM_ROW((u32)GetItemID::GI_RUPEE_BLUE, ChestType::WOODEN_SMALL,
-                        (u8)game::ItemId::ThirtyArrows, 0x001F, 0x000AF, (s8)0xFF, (s8)0xFF,
-                        (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_BUNDLE_ARROW_SMALL,
-                        (rnd::upgradeFunc)ItemUpgrade_ArrowsToRupee, ItemEffect_None, (s16)-1,
+      [0x1F] = ITEM_ROW((u32)GetItemID::GI_RUPEE_BLUE, ChestType::WOODEN_SMALL, (u8)game::ItemId::ThirtyArrows, 0x001F,
+                        0x000AF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF,
+                        (s32)DrawGraphicItemID::DI_BUNDLE_ARROW_SMALL, (rnd::upgradeFunc)ItemUpgrade_ArrowsToRupee,
+                        ItemEffect_None, (s16)-1,
                         (s16)-1),  // Arrows (30)
 
-      [0x20] = ITEM_ROW((u32)GetItemID::GI_RUPEE_BLUE, ChestType::WOODEN_SMALL,
-                        (u8)game::ItemId::FortyArrows, 0x0020, 0x000AF, (s8)0xFF, (s8)0xFF,
-                        (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_BUNDLE_ARROW_LARGE,
-                        (rnd::upgradeFunc)ItemUpgrade_ArrowsToRupee, ItemEffect_None, (s16)-1,
+      [0x20] = ITEM_ROW((u32)GetItemID::GI_RUPEE_BLUE, ChestType::WOODEN_SMALL, (u8)game::ItemId::FortyArrows, 0x0020,
+                        0x000AF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF,
+                        (s32)DrawGraphicItemID::DI_BUNDLE_ARROW_LARGE, (rnd::upgradeFunc)ItemUpgrade_ArrowsToRupee,
+                        ItemEffect_None, (s16)-1,
                         (s16)-1),  // Arrows (40)
 
-      [0x21] = ITEM_ROW((u32)GetItemID::GI_RUPEE_BLUE, ChestType::WOODEN_SMALL,
-                        (u8)game::ItemId::FiftyArrows, 0x0021, 0x000AF, (s8)0xFF, (s8)0xFF,
-                        (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_BUNDLE_ARROW_LARGE,
-                        (rnd::upgradeFunc)ItemUpgrade_ArrowsToRupee, ItemEffect_None, (s16)-1,
+      [0x21] = ITEM_ROW((u32)GetItemID::GI_RUPEE_BLUE, ChestType::WOODEN_SMALL, (u8)game::ItemId::FiftyArrows, 0x0021,
+                        0x000AF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF,
+                        (s32)DrawGraphicItemID::DI_BUNDLE_ARROW_LARGE, (rnd::upgradeFunc)ItemUpgrade_ArrowsToRupee,
+                        ItemEffect_None, (s16)-1,
                         (s16)-1),  // Arrows (50)
 
-      [0x22] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::Arrow,
-                        0x0022, 0x00BF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF,
-                        (s32)DrawGraphicItemID::DI_HERO_BOW_AND_ARROW,
-                        (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_PlaceMagicArrowsInInventory,
-                        (s16)0,
+      [0x22] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::Arrow, 0x0022, 0x00BF,
+                        (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_HERO_BOW_AND_ARROW,
+                        (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_PlaceMagicArrowsInInventory, (s16)0,
                         (s16)-1),  // Hero's Bow
 
       [0x23] =
-          ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::LargeQuiver,
-                   0x0023, 0x00097, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF,
-                   (s32)DrawGraphicItemID::DI_LARGE_QUIVER, (rnd::upgradeFunc)ItemUpgrade_None,
-                   ItemEffect_GiveUpgrade, (s16)2, (s16)0),  // Large Quiver
+          ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::LargeQuiver, 0x0023, 0x00097,
+                   (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_LARGE_QUIVER,
+                   (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_GiveUpgrade, (s16)2, (s16)0),  // Large Quiver
 
-      [0x24] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG,
-                        (u8)game::ItemId::BiggestQuiver, 0x0024, 0x00097, (s8)0xFF, (s8)0xFF,
-                        (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_BIGGEST_QUIVER,
-                        (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_GiveUpgrade, (s16)3,
-                        (s16)0),  // Biggest Quiver
+      [0x24] =
+          ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::BiggestQuiver, 0x0024, 0x00097,
+                   (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_BIGGEST_QUIVER,
+                   (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_GiveUpgrade, (s16)3,
+                   (s16)0),  // Biggest Quiver
 
-      [0x25] =
-          ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::FireArrow,
-                   0x0025, 0x00121, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF,
-                   (s32)DrawGraphicItemID::DI_FIRE_ARROW, (rnd::upgradeFunc)ItemUpgrade_None,
-                   ItemEffect_GiveUpgrade, (s16)3, (s16)0),  // Fire Arrow
+      [0x25] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::FireArrow, 0x0025, 0x00121,
+                        (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_FIRE_ARROW,
+                        (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_GiveUpgrade, (s16)3, (s16)0),  // Fire Arrow
 
-      [0x26] =
-          ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::IceArrow,
-                   0x0026, 0x00121, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF,
-                   (s32)DrawGraphicItemID::DI_ICE_ARROW, (rnd::upgradeFunc)ItemUpgrade_None,
-                   ItemEffect_GiveUpgrade, (s16)3, (s16)0),  // Ice Arrow
+      [0x26] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::IceArrow, 0x0026, 0x00121,
+                        (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_ICE_ARROW,
+                        (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_GiveUpgrade, (s16)3, (s16)0),  // Ice Arrow
 
       [0x27] =
-          ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::LightArrow,
-                   0x0027, 0x00121, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF,
-                   (s32)DrawGraphicItemID::DI_LIGHT_ARROW, (rnd::upgradeFunc)ItemUpgrade_None,
-                   ItemEffect_GiveUpgrade, (s16)3, (s16)0),  // Light Arrow
+          ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::LightArrow, 0x0027, 0x00121,
+                   (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_LIGHT_ARROW,
+                   (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_GiveUpgrade, (s16)3, (s16)0),  // Light Arrow
 
-      [0x28] = ITEM_ROW((u32)GetItemID::GI_RUPEE_BLUE, ChestType::WOODEN_SMALL,
-                        (u8)game::ItemId::DekuNuts, 0x0028, 0x0094, (s8)0xFF, (s8)0xFF, (s8)0xFF,
-                        (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_DEKU_NUT,
+      [0x28] = ITEM_ROW((u32)GetItemID::GI_RUPEE_BLUE, ChestType::WOODEN_SMALL, (u8)game::ItemId::DekuNuts, 0x0028,
+                        0x0094, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_DEKU_NUT,
                         (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1,
                         (s16)-1),  // Deku Nuts (1)
 
-      [0x29] = ITEM_ROW((u32)GetItemID::GI_RUPEE_BLUE, ChestType::WOODEN_SMALL,
-                        (u8)game::ItemId::FiveNuts, 0x0029, 0x0094, (s8)0xFF, (s8)0xFF, (s8)0xFF,
-                        (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_DEKU_NUT,
+      [0x29] = ITEM_ROW((u32)GetItemID::GI_RUPEE_BLUE, ChestType::WOODEN_SMALL, (u8)game::ItemId::FiveNuts, 0x0029,
+                        0x0094, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_DEKU_NUT,
                         (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1,
                         (s16)-1),  // Deku Nuts (5)
 
-      [0x2A] = ITEM_ROW((u32)GetItemID::GI_RUPEE_BLUE, ChestType::WOODEN_SMALL,
-                        (u8)game::ItemId::TenNuts, 0x002A, 0x0094, (s8)0xFF, (s8)0xFF, (s8)0xFF,
-                        (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_DEKU_NUT,
+      [0x2A] = ITEM_ROW((u32)GetItemID::GI_RUPEE_BLUE, ChestType::WOODEN_SMALL, (u8)game::ItemId::TenNuts, 0x002A,
+                        0x0094, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_DEKU_NUT,
                         (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1,
                         (s16)-1),  // Deku Nuts (10)
 
-      [0x2B] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG,
-                        (u8)game::ItemId::BigMagicAccumulator, 0x000CC, 0x000A4, (s8)0xFF, (s8)0xFF,
-                        (s8)0xFF, (s8)0xFF, (s8)0xFF, 0xFF, (rnd::upgradeFunc)ItemUpgrade_None,
-                        ItemEffect_GiveDoubleMagic, (s16)-1, (s16)-1),  // Double Magic
+      [0x2B] =
+          ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::BigMagicAccumulator, 0x000CC,
+                   0x000A4, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, 0xFF, (rnd::upgradeFunc)ItemUpgrade_None,
+                   ItemEffect_GiveDoubleMagic, (s16)-1, (s16)-1),  // Double Magic
 
-      [0x2C] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG,
-                        (u8)game::ItemId::BigMagicAccumulator, 0x000CA, 0x000A4, (s8)0xFF, (s8)0xFF,
-                        (s8)0xFF, (s8)0xFF, (s8)0xFF, 0xFF, (rnd::upgradeFunc)ItemUpgrade_None,
-                        ItemEffect_GiveGreatSpin, (s16)-1, (s16)-1),  // Great Spin Attack
+      [0x2C] =
+          ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::BigMagicAccumulator, 0x000CA,
+                   0x000A4, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, 0xFF, (rnd::upgradeFunc)ItemUpgrade_None,
+                   ItemEffect_GiveGreatSpin, (s16)-1, (s16)-1),  // Great Spin Attack
 
-      [0x2D] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG,
-                        (u8)game::ItemId::OdolwaRemains, 0x0055, 0x00000, (s8)0xFF, (s8)0xFF,
-                        (s8)0xFF, (s8)0xFF, (s8)0xFF, 0xFF, (rnd::upgradeFunc)ItemUpgrade_None,
-                        ItemEffect_GiveMask, (s16)0, (s16)-1),  // Odolwa's Remains
+      [0x2D] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::OdolwaRemains, 0x0055,
+                        0x00000, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, 0xFF,
+                        (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_GiveMask, (s16)0, (s16)-1),  // Odolwa's Remains
 
-      [0x2E] = ITEM_ROW((u32)GetItemID::GI_RUPEE_BLUE, ChestType::WOODEN_SMALL,
-                        (u8)game::ItemId::OneBombchu, 0x002E, 0x00B0, (s8)0xFF, (s8)0xFF, (s8)0xFF,
-                        (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_BOMBCHU,
+      [0x2E] = ITEM_ROW((u32)GetItemID::GI_RUPEE_BLUE, ChestType::WOODEN_SMALL, (u8)game::ItemId::OneBombchu, 0x002E,
+                        0x00B0, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_BOMBCHU,
                         (rnd::upgradeFunc)ItemUpgrade_BombsToRupee, ItemEffect_None, (s16)-1,
                         (s16)-1),  // Bombchu (1)
 
-      [0x2F] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG,
-                        (u8)game::ItemId::GohtRemains, 0x0056, 0x00000, (s8)0xFF, (s8)0xFF,
-                        (s8)0xFF, (s8)0xFF, (s8)0xFF, 0xFF, (rnd::upgradeFunc)ItemUpgrade_None,
-                        ItemEffect_GiveMask, (s16)1, (s16)-1),  // Goht's Remains
+      [0x2F] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::GohtRemains, 0x0056,
+                        0x00000, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, 0xFF,
+                        (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_GiveMask, (s16)1, (s16)-1),  // Goht's Remains
 
-      [0x30] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG,
-                        (u8)game::ItemId::GyorgRemains, 0x0057, 0x00000, (s8)0xFF, (s8)0xFF,
-                        (s8)0xFF, (s8)0xFF, (s8)0xFF, 0xFF, (rnd::upgradeFunc)ItemUpgrade_None,
-                        ItemEffect_GiveMask, (s16)2, (s16)-1),  // Gyrog's Remains
+      [0x30] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::GyorgRemains, 0x0057,
+                        0x00000, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, 0xFF,
+                        (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_GiveMask, (s16)2, (s16)-1),  // Gyrog's Remains
 
-      [0x31] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG,
-                        (u8)game::ItemId::TwinmoldRemains, 0x0058, 0x00000, (s8)0xFF, (s8)0xFF,
-                        (s8)0xFF, (s8)0xFF, (s8)0xFF, 0xFF, (rnd::upgradeFunc)ItemUpgrade_None,
-                        ItemEffect_GiveMask, (s16)3, (s16)-1),  // Twinmold's Remains
+      [0x31] =
+          ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::TwinmoldRemains, 0x0058,
+                   0x00000, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, 0xFF, (rnd::upgradeFunc)ItemUpgrade_None,
+                   ItemEffect_GiveMask, (s16)3, (s16)-1),  // Twinmold's Remains
 
       [0x32] =
-          ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::HeroShield,
-                   0x0032, 0x000B3, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF,
-                   (s32)DrawGraphicItemID::DI_HERO_SHIELD, (rnd::upgradeFunc)ItemUpgrade_None,
-                   ItemEffect_None, (s16)-1, (s16)-1),  // Hero Sheild
+          ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::HeroShield, 0x0032, 0x000B3,
+                   (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_HERO_SHIELD,
+                   (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1, (s16)-1),  // Hero Sheild
 
-      [0x33] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG,
-                        (u8)game::ItemId::MirrorShield, 0x0033, 0x000C3, (s8)0xFF, (s8)0xFF,
-                        (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_MIRROR_SHIELD,
-                        (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1,
-                        (s16)-1),  // Mirror Sheild
+      [0x33] =
+          ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::MirrorShield, 0x0033, 0x000C3,
+                   (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_MIRROR_SHIELD,
+                   (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1,
+                   (s16)-1),  // Mirror Sheild
 
-      [0x34] =
-          ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::PowderKeg,
-                   0x0034, 0x001CA, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF,
-                   (s32)DrawGraphicItemID::DI_POWDER_KEG, (rnd::upgradeFunc)ItemUpgrade_None,
-                   ItemEffect_None, (s16)-1, (s16)-1),  // Powder Keg
+      [0x34] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::PowderKeg, 0x0034, 0x001CA,
+                        (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_POWDER_KEG,
+                        (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1, (s16)-1),  // Powder Keg
 
-      [0x35] =
-          ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::MagicBean,
-                   0x0035, 0x000C6, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF,
-                   (s32)DrawGraphicItemID::DI_MAGIC_BEAN, (rnd::upgradeFunc)ItemUpgrade_None,
-                   ItemEffect_None, (s16)-1, (s16)-1),  // Magic Beans
+      [0x35] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::MagicBean, 0x0035, 0x000C6,
+                        (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_MAGIC_BEAN,
+                        (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1, (s16)-1),  // Magic Beans
 
-      [0x36] = ITEM_ROW((u32)GetItemID::GI_RUPEE_BLUE, ChestType::WOODEN_SMALL,
-                        (u8)game::ItemId::OneBombchu, 0x0036, 0x00B0, (s8)0xFF, (s8)0xFF, (s8)0xFF,
-                        (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_BOMBCHU,
+      [0x36] = ITEM_ROW((u32)GetItemID::GI_RUPEE_BLUE, ChestType::WOODEN_SMALL, (u8)game::ItemId::OneBombchu, 0x0036,
+                        0x00B0, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_BOMBCHU,
                         (rnd::upgradeFunc)ItemUpgrade_BombsToRupee, ItemEffect_None, (s16)-1,
                         (s16)-1),  // Bombchu (1)
 
       [0x37] =
-          ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::KokiriSword,
-                   0x0037, 0x00148, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF,
-                   (s32)DrawGraphicItemID::DI_KOKIRI_SWORD, (rnd::upgradeFunc)ItemUpgrade_None,
-                   ItemEffect_GiveKokiriSword, (s16)-1, (s16)-1),  // Kokiri Sword
+          ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::KokiriSword, 0x0037, 0x00148,
+                   (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_KOKIRI_SWORD,
+                   (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_GiveKokiriSword, (s16)-1, (s16)-1),  // Kokiri Sword
 
       [0x38] =
-          ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::RazorSword,
-                   0x0038, 0x001F9, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF,
-                   (s32)DrawGraphicItemID::DI_RAZOR_SWORD, (rnd::upgradeFunc)ItemUpgrade_None,
-                   ItemEffect_GiveRazorSword, (s16)-1, (s16)-1),  // Razor Sword
+          ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::RazorSword, 0x0038, 0x001F9,
+                   (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_RAZOR_SWORD,
+                   (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_GiveRazorSword, (s16)-1, (s16)-1),  // Razor Sword
 
       [0x39] =
-          ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::GildedSword,
-                   0x0039, 0x001FA, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF,
-                   (s32)DrawGraphicItemID::DI_GILDED_SWORD, (rnd::upgradeFunc)ItemUpgrade_None,
-                   ItemEffect_GiveGildedSword, (s16)-1, (s16)-1),  // Gilded Sword
+          ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::GildedSword, 0x0039, 0x001FA,
+                   (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_GILDED_SWORD,
+                   (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_GiveGildedSword, (s16)-1, (s16)-1),  // Gilded Sword
 
-      [0x3A] = ITEM_ROW((u32)GetItemID::GI_RUPEE_BLUE, ChestType::WOODEN_SMALL,
-                        (u8)game::ItemId::FiveBombchu, 0x003A, 0x000B0, (s8)0xFF, (s8)0xFF,
-                        (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_BOMBCHU,
+      [0x3A] = ITEM_ROW((u32)GetItemID::GI_RUPEE_BLUE, ChestType::WOODEN_SMALL, (u8)game::ItemId::FiveBombchu, 0x003A,
+                        0x000B0, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_BOMBCHU,
                         (rnd::upgradeFunc)ItemUpgrade_BombsToRupee, ItemEffect_None, (s16)-1,
                         (s16)-1),  // Bombchus (5)
 
-      [0x3B] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG,
-                        (u8)game::ItemId::GreatFairySword, 0x003B, 0x001FB, (s8)0xFF, (s8)0xFF,
-                        (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_GREAT_FAIRY_SWORD,
-                        (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1,
+      [0x3B] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::GreatFairySword, 0x003B,
+                        0x001FB, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF,
+                        (s32)DrawGraphicItemID::DI_GREAT_FAIRY_SWORD, (rnd::upgradeFunc)ItemUpgrade_None,
+                        ItemEffect_None, (s16)-1,
                         (s16)-1),  // Great Fairy Sword
 
-      [0x3C] = ITEM_ROW((u32)GetItemID::GI_RUPEE_BLUE, ChestType::DECORATED_SMALL,
-                        (u8)game::ItemId::SmallKey, 0x003C, 0x00086, (s8)0xFF, (s8)0xFF, (s8)0xFF,
-                        (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_SMALL_KEY,
+      [0x3C] = ITEM_ROW((u32)GetItemID::GI_RUPEE_BLUE, ChestType::DECORATED_SMALL, (u8)game::ItemId::SmallKey, 0x003C,
+                        0x00086, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_SMALL_KEY,
                         (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1,
                         (s16)-1),  // Small Key
 
-      [0x3D] =
-          ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::DECORATED_BIG, (u8)game::ItemId::BossKey,
-                   0x003D, 0x00092, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF,
-                   (s32)DrawGraphicItemID::DI_BOSS_KEY, (rnd::upgradeFunc)ItemUpgrade_None,
-                   ItemEffect_None, (s16)-1, (s16)-1),  // Boss Key
+      [0x3D] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::DECORATED_BIG, (u8)game::ItemId::BossKey, 0x003D,
+                        0x00092, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_BOSS_KEY,
+                        (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1, (s16)-1),  // Boss Key
 
-      [0x3E] =
-          ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::DECORATED_BIG, (u8)game::ItemId::Map,
-                   0x003E, 0x000A0, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF,
-                   (s32)DrawGraphicItemID::DI_DUNGEON_MAP_MAYBE, (rnd::upgradeFunc)ItemUpgrade_None,
-                   ItemEffect_None, (s16)-1, (s16)-1),  // Map
+      [0x3E] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::DECORATED_BIG, (u8)game::ItemId::Map, 0x003E, 0x000A0,
+                        (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_DUNGEON_MAP_MAYBE,
+                        (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1, (s16)-1),  // Map
 
-      [0x3F] =
-          ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::DECORATED_BIG, (u8)game::ItemId::Compass,
-                   0x003F, 0x00091, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF,
-                   (s32)DrawGraphicItemID::DI_COMPASS, (rnd::upgradeFunc)ItemUpgrade_None,
-                   ItemEffect_None, (s16)-1, (s16)-1),  // Compass
+      [0x3F] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::DECORATED_BIG, (u8)game::ItemId::Compass, 0x003F,
+                        0x00091, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_COMPASS,
+                        (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1, (s16)-1),  // Compass
 
-      [0x40] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG,
-                        (u8)game::ItemId::KokiriSword, 0x009C, 0x00148, (s8)0xFF, (s8)0xFF,
-                        (s8)0xFF, (s8)0xFF, (s8)0xFF, 0xFF, (rnd::upgradeFunc)ItemUpgrade_None,
-                        ItemEffect_GiveKokiriSword, (s16)-1, (s16)-1),  // Kokiri Sword
+      [0x40] =
+          ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::KokiriSword, 0x009C, 0x00148,
+                   (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, 0xFF, (rnd::upgradeFunc)ItemUpgrade_None,
+                   ItemEffect_GiveKokiriSword, (s16)-1, (s16)-1),  // Kokiri Sword
 
-      [0x41] =
-          ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::Hookshot,
-                   0x0041, 0x00BF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF,
-                   (s32)DrawGraphicItemID::DI_HOOKSHOT, (rnd::upgradeFunc)ItemUpgrade_None,
-                   ItemEffect_None, (s16)-1, (s16)-1),  // Hookshot
+      [0x41] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::Hookshot, 0x0041, 0x00BF,
+                        (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_HOOKSHOT,
+                        (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1, (s16)-1),  // Hookshot
 
-      [0x42] = ITEM_ROW((u32)GetItemID::GI_RUPEE_BLUE, ChestType::WOODEN_SMALL,
-                        (u8)game::ItemId::LensOfTruth, 0x0042, 0x00C0, (s8)0xFF, (s8)0xFF, (s8)0xFF,
-                        (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_LENS_OF_TRUTH,
-                        (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1,
-                        (s16)-1),  // Lens of Truth
+      [0x42] =
+          ITEM_ROW((u32)GetItemID::GI_RUPEE_BLUE, ChestType::WOODEN_SMALL, (u8)game::ItemId::LensOfTruth, 0x0042,
+                   0x00C0, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_LENS_OF_TRUTH,
+                   (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1,
+                   (s16)-1),  // Lens of Truth
 
-      [0x43] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG,
-                        (u8)game::ItemId::PictographBox, 0x0043, 0x00228, (s8)0xFF, (s8)0xFF,
-                        (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_PICTOGRAPH_BOX,
-                        (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1,
-                        (s16)-1),  // Pictograph Box
+      [0x43] =
+          ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::PictographBox, 0x0043, 0x00228,
+                   (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_PICTOGRAPH_BOX,
+                   (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1,
+                   (s16)-1),  // Pictograph Box
 
-      [0x44] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_SMALL,
-                        (u8)game::ItemId::GoldSkulltula, 0x0052, 0x00125, (s8)0xFF, (s8)0xFF,
-                        (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_GOLD_SKULLTULA,
-                        (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_GiveSkulltula, (s16)0,
-                        (s16)-1),  // Gold Skulltula - Swamp
+      [0x44] =
+          ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_SMALL, (u8)game::ItemId::GoldSkulltula, 0x0052,
+                   0x00125, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_GOLD_SKULLTULA,
+                   (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_GiveSkulltula, (s16)0,
+                   (s16)-1),  // Gold Skulltula - Swamp
 
-      [0x45] = ITEM_ROW((u32)GetItemID::GI_RUPEE_BLUE, ChestType::WOODEN_SMALL,
-                        (u8)game::ItemId::RecoveryHeart, 0x0045, 0x00090, (s8)0xFF, (s8)0xFF,
-                        (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_RECOVERY_HEART,
-                        (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1,
-                        (s16)-1),  // Recovery Heart - Broken Text
+      [0x45] =
+          ITEM_ROW((u32)GetItemID::GI_RUPEE_BLUE, ChestType::WOODEN_SMALL, (u8)game::ItemId::RecoveryHeart, 0x0045,
+                   0x00090, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_RECOVERY_HEART,
+                   (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1,
+                   (s16)-1),  // Recovery Heart - Broken Text
 
-      [0x46] = ITEM_ROW(0xFF, ChestType::WOODEN_SMALL, 0xFF, 0xFF, 0x00098, (s8)0xFF, (s8)0xFF,
-                        (s8)0xFF, (s8)0xFF, (s8)0xFF, 0xFF, (rnd::upgradeFunc)ItemUpgrade_BombBag,
-                        ItemEffect_None, (s16)-1,
+      [0x46] = ITEM_ROW(0xFF, ChestType::WOODEN_SMALL, 0xFF, 0xFF, 0x00098, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF,
+                        (s8)0xFF, 0xFF, (rnd::upgradeFunc)ItemUpgrade_BombBag, ItemEffect_None, (s16)-1,
                         (s16)-1),  // Progressive Bomb Bag
 
-      [0x47] = ITEM_ROW(0xFF, ChestType::WOODEN_SMALL, 0xFF, 0xFF, 0x00097, (s8)0xFF, (s8)0xFF,
-                        (s8)0xFF, (s8)0xFF, (s8)0xFF, 0xFF, (rnd::upgradeFunc)ItemUpgrade_Quiver,
-                        ItemEffect_None, (s16)-1, (s16)-1),  // Progressive Quiver
+      [0x47] = ITEM_ROW(0xFF, ChestType::WOODEN_SMALL, 0xFF, 0xFF, 0x00097, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF,
+                        (s8)0xFF, 0xFF, (rnd::upgradeFunc)ItemUpgrade_Quiver, ItemEffect_None, (s16)-1,
+                        (s16)-1),  // Progressive Quiver
 
-      [0x48] = ITEM_ROW(0xFF, ChestType::WOODEN_SMALL, 0xFF, 0xFF, 0x000A8, (s8)0xFF, (s8)0xFF,
-                        (s8)0xFF, (s8)0xFF, (s8)0xFF, 0xFF, (rnd::upgradeFunc)ItemUpgrade_Wallet,
-                        ItemEffect_None, (s16)-1, (s16)-1),  // Progressive Wallet
+      [0x48] = ITEM_ROW(0xFF, ChestType::WOODEN_SMALL, 0xFF, 0xFF, 0x000A8, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF,
+                        (s8)0xFF, 0xFF, (rnd::upgradeFunc)ItemUpgrade_Wallet, ItemEffect_None, (s16)-1,
+                        (s16)-1),  // Progressive Wallet
 
-      [0x49] = ITEM_ROW(0xFF, ChestType::WOODEN_SMALL, 0xFF, 0xFF, 0x000A4, (s8)0xFF, (s8)0xFF,
-                        (s8)0xFF, (s8)0xFF, (s8)0xFF, 0xFF, (rnd::upgradeFunc)ItemUpgrade_Magic,
-                        ItemEffect_GiveProgressiveMagic, (s16)-1, (s16)-1),  // Progressive Magic
+      [0x49] = ITEM_ROW(0xFF, ChestType::WOODEN_SMALL, 0xFF, 0xFF, 0x000A4, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF,
+                        (s8)0xFF, 0xFF, (rnd::upgradeFunc)ItemUpgrade_Magic, ItemEffect_GiveProgressiveMagic, (s16)-1,
+                        (s16)-1),  // Progressive Magic
 
-      [0x4A] = ITEM_ROW(0xFF, ChestType::WOODEN_SMALL, 0xFF, 0xFF, 0x001FA, (s8)0xFF, (s8)0xFF,
-                        (s8)0xFF, (s8)0xFF, (s8)0xFF, 0xFF, (rnd::upgradeFunc)ItemUpgrade_Sword,
-                        ItemEffect_None, (s16)-1, (s16)-1),  // Progressive Sword
+      [0x4A] =
+          ITEM_ROW(0xFF, ChestType::WOODEN_SMALL, 0xFF, 0xFF, 0x001FA, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF,
+                   0xFF, (rnd::upgradeFunc)ItemUpgrade_Sword, ItemEffect_None, (s16)-1, (s16)-1),  // Progressive Sword
 
-      [0x4B] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG,
-                        (u8)game::ItemId::SonataOfAwakening, 0x1B9E, 0x00000, (s8)0xFF, (s8)0xFF,
-                        (s8)0xFF, (s8)0xFF, (s8)0xFF, 0xFF, (rnd::upgradeFunc)ItemUpgrade_None,
-                        ItemEffect_GiveSong, (s16)1, (s16)-1),  // Sonata Of Awakening
+      [0x4B] =
+          ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::SonataOfAwakening, 0x1B9E,
+                   0x00000, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, 0xFF, (rnd::upgradeFunc)ItemUpgrade_None,
+                   ItemEffect_GiveSong, (s16)1, (s16)-1),  // Sonata Of Awakening
 
-      [0x4C] =
-          ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::Ocarina,
-                   0x004C, 0x000B5, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF,
-                   (s32)DrawGraphicItemID::DI_OCARINA_OF_TIME, (rnd::upgradeFunc)ItemUpgrade_None,
-                   ItemEffect_None, (s16)-1, (s16)-1),  // Ocarina
+      [0x4C] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::Ocarina, 0x004C, 0x000B5,
+                        (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_OCARINA_OF_TIME,
+                        (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1, (s16)-1),  // Ocarina
 
-      [0x4D] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG,
-                        (u8)game::ItemId::GoronLullaby, 0x1B9F, 0x00000, (s8)0xFF, (s8)0xFF,
-                        (s8)0xFF, (s8)0xFF, (s8)0xFF, 0xFF, (rnd::upgradeFunc)ItemUpgrade_None,
-                        ItemEffect_GiveSong, (s16)2, (s16)-1),  // Goron Lullaby
+      [0x4D] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::GoronLullaby, 0x1B9F,
+                        0x00000, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, 0xFF,
+                        (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_GiveSong, (s16)2, (s16)-1),  // Goron Lullaby
 
-      [0x4E] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG,
-                        (u8)game::ItemId::NewWaveBossaNova, 0x1BA0, 0x00000, (s8)0xFF, (s8)0xFF,
-                        (s8)0xFF, (s8)0xFF, (s8)0xFF, 0xFF, (rnd::upgradeFunc)ItemUpgrade_None,
-                        ItemEffect_GiveSong, (s16)3, (s16)-1),  // New Wave Bossanova
+      [0x4E] =
+          ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::NewWaveBossaNova, 0x1BA0,
+                   0x00000, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, 0xFF, (rnd::upgradeFunc)ItemUpgrade_None,
+                   ItemEffect_GiveSong, (s16)3, (s16)-1),  // New Wave Bossanova
 
-      [0x4F] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG,
-                        (u8)game::ItemId::ElegyOfEmptiness, 0x1BA1, 0x00000, (s8)0xFF, (s8)0xFF,
-                        (s8)0xFF, (s8)0xFF, (s8)0xFF, 0xFF, (rnd::upgradeFunc)ItemUpgrade_None,
-                        ItemEffect_GiveSong, (s16)4, (s16)-1),  // Elegy of Emptiness
+      [0x4F] =
+          ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::ElegyOfEmptiness, 0x1BA1,
+                   0x00000, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, 0xFF, (rnd::upgradeFunc)ItemUpgrade_None,
+                   ItemEffect_GiveSong, (s16)4, (s16)-1),  // Elegy of Emptiness
 
-      [0x50] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG,
-                        (u8)game::ItemId::BombersNotebook, 0x0050, 0x00253, (s8)0xFF, (s8)0xFF,
-                        (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_BOMBERS_NOTEBOOK,
-                        (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1,
+      [0x50] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::BombersNotebook, 0x0050,
+                        0x00253, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF,
+                        (s32)DrawGraphicItemID::DI_BOMBERS_NOTEBOOK, (rnd::upgradeFunc)ItemUpgrade_None,
+                        ItemEffect_None, (s16)-1,
                         (s16)-1),  // Bombers Notebook
 
-      [0x51] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG,
-                        (u8)game::ItemId::OathToOrder, 0x1BA2, 0x00000, (s8)0xFF, (s8)0xFF,
-                        (s8)0xFF, (s8)0xFF, (s8)0xFF, 0xFF, (rnd::upgradeFunc)ItemUpgrade_None,
-                        ItemEffect_GiveSong, (s16)5, (s16)-1),  // Oath To Order
+      [0x51] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::OathToOrder, 0x1BA2,
+                        0x00000, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, 0xFF,
+                        (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_GiveSong, (s16)5, (s16)-1),  // Oath To Order
 
-      [0x52] = ITEM_ROW((u32)GetItemID::GI_RUPEE_BLUE, ChestType::WOODEN_SMALL,
-                        (u8)game::ItemId::GoldSkulltula, 0x0052, 0x00125, (s8)0xFF, (s8)0xFF,
-                        (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_GOLD_SKULLTULA,
-                        (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1,
-                        (s16)-1),  // Gold Skulltula - Messed Up Item
+      [0x52] =
+          ITEM_ROW((u32)GetItemID::GI_RUPEE_BLUE, ChestType::WOODEN_SMALL, (u8)game::ItemId::GoldSkulltula, 0x0052,
+                   0x00125, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_GOLD_SKULLTULA,
+                   (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1,
+                   (s16)-1),  // Gold Skulltula - Messed Up Item
 
-      [0x53] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG,
-                        (u8)game::ItemId::SongOfTime, 0x1BA4, 0x00000, (s8)0xFF, (s8)0xFF, (s8)0xFF,
-                        (s8)0xFF, (s8)0xFF, 0xFF, (rnd::upgradeFunc)ItemUpgrade_None,
-                        ItemEffect_GiveSong, (s16)6, (s16)-1),  // Song Of Time
+      [0x53] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::SongOfTime, 0x1BA4,
+                        0x00000, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, 0xFF,
+                        (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_GiveSong, (s16)6, (s16)-1),  // Song Of Time
 
-      [0x54] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG,
-                        (u8)game::ItemId::SongOfHealing, 0x1BA5, 0x00000, (s8)0xFF, (s8)0xFF,
-                        (s8)0xFF, (s8)0xFF, (s8)0xFF, 0xFF, (rnd::upgradeFunc)ItemUpgrade_None,
-                        ItemEffect_GiveSong, (s16)7, (s16)-1),  // Song Of Healing
+      [0x54] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::SongOfHealing, 0x1BA5,
+                        0x00000, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, 0xFF,
+                        (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_GiveSong, (s16)7, (s16)-1),  // Song Of Healing
 
-      [0x55] = ITEM_ROW((u32)GetItemID::GI_HEART_CONTAINER, ChestType::WOODEN_BIG,
-                        (u8)game::ItemId::OdolwaRemains, 0x0055, 0x00000, (s8)0xFF, (s8)0xFF,
-                        (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_ODOLWAS_REMAINS,
-                        (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_GiveMask, (s16)0,
+      [0x55] = ITEM_ROW((u32)GetItemID::GI_HEART_CONTAINER, ChestType::WOODEN_BIG, (u8)game::ItemId::OdolwaRemains,
+                        0x0055, 0x00000, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF,
+                        (s32)DrawGraphicItemID::DI_ODOLWAS_REMAINS, (rnd::upgradeFunc)ItemUpgrade_None,
+                        ItemEffect_GiveMask, (s16)0,
                         (s16)-1),  // Odolwa's Remains
 
       [0x56] =
-          ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::GohtRemains,
-                   0x0056, 0x00000, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF,
-                   (s32)DrawGraphicItemID::DI_GOHTS_REMAINS, (rnd::upgradeFunc)ItemUpgrade_None,
-                   ItemEffect_GiveMask, (s16)1, (s16)-1),  // Goht's Remains
+          ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::GohtRemains, 0x0056, 0x00000,
+                   (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_GOHTS_REMAINS,
+                   (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_GiveMask, (s16)1, (s16)-1),  // Goht's Remains
 
-      [0x57] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG,
-                        (u8)game::ItemId::GyorgRemains, 0x0057, 0x00000, (s8)0xFF, (s8)0xFF,
-                        (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_GYORGS_REMAINS,
-                        (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_GiveMask, (s16)2,
-                        (s16)-1),  // Gyrog's Remains
+      [0x57] =
+          ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::GyorgRemains, 0x0057, 0x00000,
+                   (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_GYORGS_REMAINS,
+                   (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_GiveMask, (s16)2,
+                   (s16)-1),  // Gyrog's Remains
 
-      [0x58] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG,
-                        (u8)game::ItemId::TwinmoldRemains, 0x0058, 0x00000, (s8)0xFF, (s8)0xFF,
-                        (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_TWINMOLDS_REMAINS,
-                        (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_GiveMask, (s16)3,
+      [0x58] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::TwinmoldRemains, 0x0058,
+                        0x00000, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF,
+                        (s32)DrawGraphicItemID::DI_TWINMOLDS_REMAINS, (rnd::upgradeFunc)ItemUpgrade_None,
+                        ItemEffect_GiveMask, (s16)3,
                         (s16)-1),  // Twinmold's Remains
 
-      [0x59] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG,
-                        (u8)game::ItemId::HookshotUnused, 0x0059, 0x00196, (s8)0xFF, (s8)0xFF,
-                        (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_HOOKSHOT_TWO,
-                        (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)3,
-                        (s16)-1),  // Red Potion?
+      [0x59] =
+          ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::HookshotUnused, 0x0059, 0x00196,
+                   (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_HOOKSHOT_TWO,
+                   (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)3,
+                   (s16)-1),  // Red Potion?
 
-      [0x5A] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::Bottle,
-                        0x005A, 0x009E, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF,
-                        (s32)DrawGraphicItemID::DI_EMPTY_BOTTLE, (rnd::upgradeFunc)ItemUpgrade_None,
-                        ItemEffect_None, (s16)-1, (s16)-1),  // Empty Bottle
+      [0x5A] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::Bottle, 0x005A, 0x009E,
+                        (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_EMPTY_BOTTLE,
+                        (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1, (s16)-1),  // Empty Bottle
 
       [0x5B] =
-          ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::RedPotion,
-                   0x005B, 0x00C1, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF,
-                   (s32)DrawGraphicItemID::DI_RED_POTION, (rnd::upgradeFunc)ItemUpgrade_None,
-                   ItemEffect_None, (s16)-1, (s16)-1),  // Bottle With Red Potion
+          ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::RedPotion, 0x005B, 0x00C1,
+                   (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_RED_POTION,
+                   (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1, (s16)-1),  // Bottle With Red Potion
 
       [0x5C] =
-          ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::GreenPotion,
-                   0x005C, 0x00C1, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF,
-                   (s32)DrawGraphicItemID::DI_GREEN_POTION, (rnd::upgradeFunc)ItemUpgrade_None,
-                   ItemEffect_None, (s16)-1, (s16)-1),  // Bottle With Green Potion
+          ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::GreenPotion, 0x005C, 0x00C1,
+                   (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_GREEN_POTION,
+                   (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1, (s16)-1),  // Bottle With Green Potion
 
       [0x5D] =
-          ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::BluePotion,
-                   0x005D, 0x00C1, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF,
-                   (s32)DrawGraphicItemID::DI_BLUE_POTION, (rnd::upgradeFunc)ItemUpgrade_None,
-                   ItemEffect_None, (s16)-1, (s16)-1),  // Bottle With Blue Potion
+          ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::BluePotion, 0x005D, 0x00C1,
+                   (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_BLUE_POTION,
+                   (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1, (s16)-1),  // Bottle With Blue Potion
 
-      [0x5E] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::Fairy,
-                        0x005E, 0x0272, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF,
-                        (s32)DrawGraphicItemID::DI_BOTTLE_FAIRY, (rnd::upgradeFunc)ItemUpgrade_None,
-                        ItemEffect_None, (s16)-1, (s16)-1),  // Bottle With Fairy
+      [0x5E] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::Fairy, 0x005E, 0x0272,
+                        (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_BOTTLE_FAIRY,
+                        (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1, (s16)-1),  // Bottle With Fairy
 
-      [0x5F] = ITEM_ROW(
-          (u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::DekuPrincess, 0x005F,
-          0x009E, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF,
-          (s32)DrawGraphicItemID::DI_BOTTLE_DEKU_PRINCESS, (rnd::upgradeFunc)ItemUpgrade_None,
-          ItemEffect_None, (s16)-1, (s16)-1),  // Bottle With Deku Princess
+      [0x5F] =
+          ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::DekuPrincess, 0x005F, 0x009E,
+                   (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_BOTTLE_DEKU_PRINCESS,
+                   (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1, (s16)-1),  // Bottle With Deku Princess
 
-      [0x60] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::Milk,
-                        0x0060, 0x00B6, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF,
-                        (s32)DrawGraphicItemID::DI_MILK_FULL, (rnd::upgradeFunc)ItemUpgrade_None,
-                        ItemEffect_None, (s16)-1, (s16)-1),  // Bottle With Milk
+      [0x60] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::Milk, 0x0060, 0x00B6,
+                        (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_MILK_FULL,
+                        (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1, (s16)-1),  // Bottle With Milk
 
-      [0x61] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::Milk,
-                        0x0061, 0x00B6, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF,
-                        (s32)DrawGraphicItemID::DI_MILK_FULL, (rnd::upgradeFunc)ItemUpgrade_None,
-                        ItemEffect_None, (s16)-1, (s16)-1),  // Bottle With Half Milk
+      [0x61] =
+          ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::Milk, 0x0061, 0x00B6, (s8)0xFF,
+                   (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_MILK_FULL,
+                   (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1, (s16)-1),  // Bottle With Half Milk
 
-      [0x62] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::Fish,
-                        0x0062, 0x00C7, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF,
-                        (s32)DrawGraphicItemID::DI_BOTTLE_FISH, (rnd::upgradeFunc)ItemUpgrade_None,
-                        ItemEffect_None, (s16)-1, (s16)-1),  // Bottle With Fish
+      [0x62] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::Fish, 0x0062, 0x00C7,
+                        (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_BOTTLE_FISH,
+                        (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1, (s16)-1),  // Bottle With Fish
 
-      [0x63] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::Bug,
-                        0x0063, 0x0137, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF,
-                        (s32)DrawGraphicItemID::DI_BOTTLE_BUG, (rnd::upgradeFunc)ItemUpgrade_None,
-                        ItemEffect_None, (s16)-1, (s16)-1),  // Bottle With Bug
+      [0x63] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::Bug, 0x0063, 0x0137,
+                        (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_BOTTLE_BUG,
+                        (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1, (s16)-1),  // Bottle With Bug
 
-      [0x64] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG,
-                        (u8)game::ItemId::BlueFire, 0x0064, 0x000, (s8)0xFF, (s8)0xFF, (s8)0xFF,
-                        (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_NONE,
+      [0x64] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::BlueFire, 0x0064, 0x000,
+                        (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_NONE,
                         (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1,
                         (s16)-1),  // Bottle With Blue fire - not used
 
-      [0x65] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::Poe,
-                        0x0065, 0x009E, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF,
-                        (s32)DrawGraphicItemID::DI_BOTTLE_BIG_POE_PURPLE,
-                        (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1,
-                        (s16)-1),  // Bottle With Poe - not used?
-
-      [0x66] =
-          ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::BigPoe,
-                   0x0066, 0x0139, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF,
-                   (s32)DrawGraphicItemID::DI_BOTTLE_BIG_POE, (rnd::upgradeFunc)ItemUpgrade_None,
-                   ItemEffect_None, (s16)-1, (s16)-1),  // Bottle With Big Poe
-
-      [0x67] =
-          ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::Water,
-                   0x0067, 0x0000, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF,
-                   (s32)DrawGraphicItemID::DI_BOTTLE_WATER_HALF, (rnd::upgradeFunc)ItemUpgrade_None,
-                   ItemEffect_None, (s16)-1, (s16)-1),  // Bottle With Water
-
-      [0x68] =
-          ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG,
-                   (u8)game::ItemId::HotSpringWater, 0x0068, 0x0000, (s8)0xFF, (s8)0xFF, (s8)0xFF,
-                   (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_BOTTLE_HOT_SPRING_WATER_HALF,
+      [0x65] =
+          ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::Poe, 0x0065, 0x009E, (s8)0xFF,
+                   (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_BOTTLE_BIG_POE_PURPLE,
                    (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1,
-                   (s16)-1),  // Bottle With Hot Spring Water
+                   (s16)-1),  // Bottle With Poe - not used?
 
-      [0x69] =
-          ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::ZoraEgg,
-                   0x0069, 0x01AE, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF,
-                   (s32)DrawGraphicItemID::DI_BOTTLE_ZORA_EGG, (rnd::upgradeFunc)ItemUpgrade_None,
-                   ItemEffect_None, (s16)-1, (s16)-1),  // Bottle With Zora Egg
+      [0x66] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::BigPoe, 0x0066, 0x0139,
+                        (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_BOTTLE_BIG_POE,
+                        (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1, (s16)-1),  // Bottle With Big Poe
+
+      [0x67] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::Water, 0x0067, 0x0000,
+                        (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_BOTTLE_WATER_HALF,
+                        (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1, (s16)-1),  // Bottle With Water
+
+      [0x68] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::HotSpringWater, 0x0068,
+                        0x0000, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF,
+                        (s32)DrawGraphicItemID::DI_BOTTLE_HOT_SPRING_WATER_HALF, (rnd::upgradeFunc)ItemUpgrade_None,
+                        ItemEffect_None, (s16)-1,
+                        (s16)-1),  // Bottle With Hot Spring Water
+
+      [0x69] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::ZoraEgg, 0x0069, 0x01AE,
+                        (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_BOTTLE_ZORA_EGG,
+                        (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1, (s16)-1),  // Bottle With Zora Egg
 
       [0x6A] =
-          ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::GoldDust,
-                   0x006A, 0x01E9, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF,
-                   (s32)DrawGraphicItemID::DI_GOLD_DUST, (rnd::upgradeFunc)ItemUpgrade_None,
-                   ItemEffect_None, (s16)-1, (s16)-1),  // Bottle With Gold Dust
+          ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::GoldDust, 0x006A, 0x01E9,
+                   (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_GOLD_DUST,
+                   (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1, (s16)-1),  // Bottle With Gold Dust
 
-      [0x6B] = ITEM_ROW(
-          (u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::MagicalMushroom,
-          0x006B, 0x021D, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF,
-          (s32)DrawGraphicItemID::DI_BOTTLE_MAGIC_MUSHROOM, (rnd::upgradeFunc)ItemUpgrade_None,
-          ItemEffect_None, (s16)-1, (s16)-1),  // Bottle With Magic Mushrooms
+      [0x6B] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::MagicalMushroom, 0x006B,
+                        0x021D, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF,
+                        (s32)DrawGraphicItemID::DI_BOTTLE_MAGIC_MUSHROOM, (rnd::upgradeFunc)ItemUpgrade_None,
+                        ItemEffect_None, (s16)-1, (s16)-1),  // Bottle With Magic Mushrooms
 
-      [0x6C] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG,
-                        (u8)game::ItemId::EponaSong, 0x1BA6, 0x00000, (s8)0xFF, (s8)0xFF, (s8)0xFF,
-                        (s8)0xFF, (s8)0xFF, 0xFF, (rnd::upgradeFunc)ItemUpgrade_None,
+      [0x6C] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::EponaSong, 0x1BA6, 0x00000,
+                        (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, 0xFF, (rnd::upgradeFunc)ItemUpgrade_None,
                         ItemEffect_GiveSong, (s16)8, (s16)-1),  // Epona's Song
 
-      [0x6D] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_SMALL,
-                        (u8)game::ItemId::GoldSkulltula, 0x0052, 0x00125, (s8)0xFF, (s8)0xFF,
-                        (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_GOLD_SKULLTULA,
-                        (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_GiveSkulltula, (s16)1,
-                        (s16)-1),  // Gold Skulltula - Ocean
+      [0x6D] =
+          ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_SMALL, (u8)game::ItemId::GoldSkulltula, 0x0052,
+                   0x00125, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_GOLD_SKULLTULA,
+                   (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_GiveSkulltula, (s16)1,
+                   (s16)-1),  // Gold Skulltula - Ocean
 
-      [0x6E] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG,
-                        (u8)game::ItemId::SeaHorse, 0x006E, 0x01E9, (s8)0xFF, (s8)0xFF, (s8)0xFF,
-                        (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_BOTTLE_SEAHORSE,
+      [0x6E] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::SeaHorse, 0x006E, 0x01E9,
+                        (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_BOTTLE_SEAHORSE,
                         (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1,
                         (s16)-1),  // Bottle With Sea Horse - Gold Dust Object
 
-      [0x6F] = ITEM_ROW(
-          (u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::ChateauRomani,
-          0x006F, 0x0227, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF,
-          (s32)DrawGraphicItemID::DI_BOTTLE_CHATEAU_ROMANI, (rnd::upgradeFunc)ItemUpgrade_None,
-          ItemEffect_None, (s16)-1, (s16)-1),  // Bottle With Chateau Romani
+      [0x6F] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::ChateauRomani, 0x006F,
+                        0x0227, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF,
+                        (s32)DrawGraphicItemID::DI_BOTTLE_CHATEAU_ROMANI, (rnd::upgradeFunc)ItemUpgrade_None,
+                        ItemEffect_None, (s16)-1, (s16)-1),  // Bottle With Chateau Romani
 
       // XXX: Trade Item, may have to change values? Seems rather individual and leads to fishing
       // pass.
-      [0x70] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG,
-                        (u8)game::ItemId::MysteryMilk, 0x00CE, 0x00B6, (s8)0xFF, (s8)0xFF, (s8)0xFF,
-                        (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_BOTTLE_MYSTERY_MILK,
-                        (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1,
-                        (s16)-1),  // Bottle With Mystery Milk
+      [0x70] =
+          ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::MysteryMilk, 0x00CE, 0x00B6,
+                   (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_BOTTLE_MYSTERY_MILK,
+                   (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1,
+                   (s16)-1),  // Bottle With Mystery Milk
 
-      [0x71] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG,
-                        (u8)game::ItemId::MysteryMilk, 0x00CE, 0x00B6, (s8)0xFF, (s8)0xFF, (s8)0xFF,
-                        (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_BOTTLE_MYSTERY_MILK,
-                        (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1,
-                        (s16)-1),  // Bottle With Spoiled Mystery Milk
+      [0x71] =
+          ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::MysteryMilk, 0x00CE, 0x00B6,
+                   (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_BOTTLE_MYSTERY_MILK,
+                   (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1,
+                   (s16)-1),  // Bottle With Spoiled Mystery Milk
 
-      [0x72] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG,
-                        (u8)game::ItemId::SongOfSoaring, 0x1BA7, 0x00000, (s8)0xFF, (s8)0xFF,
-                        (s8)0xFF, (s8)0xFF, (s8)0xFF, 0xFF, (rnd::upgradeFunc)ItemUpgrade_None,
-                        ItemEffect_GiveSong, (s16)9, (s16)-1),  // Song Of Soaring
+      [0x72] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::SongOfSoaring, 0x1BA7,
+                        0x00000, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, 0xFF,
+                        (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_GiveSong, (s16)9, (s16)-1),  // Song Of Soaring
 
-      [0x73] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG,
-                        (u8)game::ItemId::SongOfStorms, 0x1BA8, 0x00000, (s8)0xFF, (s8)0xFF,
-                        (s8)0xFF, (s8)0xFF, (s8)0xFF, 0xFF, (rnd::upgradeFunc)ItemUpgrade_None,
-                        ItemEffect_GiveSong, (s16)10, (s16)-1),  // Song Of Storms
+      [0x73] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::SongOfStorms, 0x1BA8,
+                        0x00000, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, 0xFF,
+                        (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_GiveSong, (s16)10, (s16)-1),  // Song Of Storms
 
-      [0x74] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG,
-                        (u8)game::ItemId::GoronLullaby, 0x1BAC, 0x00000, (s8)0xFF, (s8)0xFF,
-                        (s8)0xFF, (s8)0xFF, (s8)0xFF, 0xFF, (rnd::upgradeFunc)ItemUpgrade_None,
-                        ItemEffect_GiveSong, (s16)11, (s16)-1),  // Goron Lullaby Intro
+      [0x74] =
+          ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::GoronLullaby, 0x1BAC, 0x00000,
+                   (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, 0xFF, (rnd::upgradeFunc)ItemUpgrade_None,
+                   ItemEffect_GiveSong, (s16)11, (s16)-1),  // Goron Lullaby Intro
 
-      [0x75] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG,
-                        (u8)game::ItemId::MagicBean, 0x0035, 0x000C6, (s8)0xFF, (s8)0xFF, (s8)0xFF,
-                        (s8)0xFF, (s8)0xFF, 0xFF, (rnd::upgradeFunc)ItemUpgrade_None,
+      [0x75] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::MagicBean, 0x0035, 0x000C6,
+                        (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, 0xFF, (rnd::upgradeFunc)ItemUpgrade_None,
                         ItemEffect_BeanPack, (s16)-1, (s16)-1),  // Magic Beans
 
-      [0x76] = ITEM_ROW((u32)GetItemID::GI_RUPEE_BLUE, ChestType::DECORATED_SMALL,
-                        (u8)game::ItemId::SmallKey, 0x003C, 0x00086, (s8)0xFF, (s8)0xFF, (s8)0xFF,
-                        (s8)0xFF, (s8)0xFF, 0xFF, (rnd::upgradeFunc)ItemUpgrade_None,
-                        ItemEffect_GiveSmallKey, (s16)0, (s16)-1),  // Small Key (Woodfall)
+      [0x76] =
+          ITEM_ROW((u32)GetItemID::GI_RUPEE_BLUE, ChestType::DECORATED_SMALL, (u8)game::ItemId::SmallKey, 0x003C,
+                   0x00086, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, 0xFF, (rnd::upgradeFunc)ItemUpgrade_None,
+                   ItemEffect_GiveSmallKey, (s16)0, (s16)-1),  // Small Key (Woodfall)
 
-      [0x77] = ITEM_ROW((u32)GetItemID::GI_RUPEE_BLUE, ChestType::DECORATED_SMALL,
-                        (u8)game::ItemId::SmallKey, 0x003C, 0x00086, (s8)0xFF, (s8)0xFF, (s8)0xFF,
-                        (s8)0xFF, (s8)0xFF, 0xFF, (rnd::upgradeFunc)ItemUpgrade_None,
-                        ItemEffect_GiveSmallKey, (s16)1, (s16)-1),  // Small Key (Snowhead)
+      [0x77] =
+          ITEM_ROW((u32)GetItemID::GI_RUPEE_BLUE, ChestType::DECORATED_SMALL, (u8)game::ItemId::SmallKey, 0x003C,
+                   0x00086, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, 0xFF, (rnd::upgradeFunc)ItemUpgrade_None,
+                   ItemEffect_GiveSmallKey, (s16)1, (s16)-1),  // Small Key (Snowhead)
 
-      [0x78] =
-          ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::DekuMask,
-                   0x0078, 0x01BD, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF,
-                   (s32)DrawGraphicItemID::DI_DEKU_MASK, (rnd::upgradeFunc)ItemUpgrade_None,
-                   ItemEffect_None, (s16)-1, (s16)-1),  // Deku Mask
+      [0x78] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::DekuMask, 0x0078, 0x01BD,
+                        (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_DEKU_MASK,
+                        (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1, (s16)-1),  // Deku Mask
 
-      [0x79] =
-          ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::GoronMask,
-                   0x0079, 0x0119, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF,
-                   (s32)DrawGraphicItemID::DI_GORON_MASK, (rnd::upgradeFunc)ItemUpgrade_None,
-                   ItemEffect_None, (s16)-1, (s16)-1),  // Goron Mask
+      [0x79] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::GoronMask, 0x0079, 0x0119,
+                        (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_GORON_MASK,
+                        (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1, (s16)-1),  // Goron Mask
 
-      [0x7A] =
-          ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::ZoraMask,
-                   0x007A, 0x011A, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF,
-                   (s32)DrawGraphicItemID::DI_ZORA_MASK, (rnd::upgradeFunc)ItemUpgrade_None,
-                   ItemEffect_None, (s16)-1, (s16)-1),  // Zora Mask
+      [0x7A] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::ZoraMask, 0x007A, 0x011A,
+                        (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_ZORA_MASK,
+                        (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1, (s16)-1),  // Zora Mask
 
-      [0x7B] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG,
-                        (u8)game::ItemId::FierceDeityMask, 0x007B, 0x0242, (s8)0xFF, (s8)0xFF,
-                        (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_FIERCE_DEITY_MASK,
-                        (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1,
-                        (s16)-1),  // Fierce Deity Mask
+      [0x7B] =
+          ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::FierceDeityMask, 0x007B, 0x0242,
+                   (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_FIERCE_DEITY_MASK,
+                   (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1,
+                   (s16)-1),  // Fierce Deity Mask
 
-      [0x7C] =
-          ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::CaptainHat,
-                   0x007C, 0x0102, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF,
-                   (s32)DrawGraphicItemID::DI_CAPTAINS_HAT, (rnd::upgradeFunc)ItemUpgrade_None,
-                   ItemEffect_None, (s16)-1, (s16)-1),  // Captain Hat
+      [0x7C] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::CaptainHat, 0x007C, 0x0102,
+                        (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_CAPTAINS_HAT,
+                        (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1, (s16)-1),  // Captain Hat
 
-      [0x7D] =
-          ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::GiantMask,
-                   0x007D, 0x0226, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF,
-                   (s32)DrawGraphicItemID::DI_GIANTS_MASK, (rnd::upgradeFunc)ItemUpgrade_None,
-                   ItemEffect_None, (s16)-1, (s16)-1),  // Giant Mask
+      [0x7D] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::GiantMask, 0x007D, 0x0226,
+                        (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_GIANTS_MASK,
+                        (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1, (s16)-1),  // Giant Mask
 
-      [0x7E] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG,
-                        (u8)game::ItemId::AllNightMask, 0x007E, 0x0265, (s8)0xFF, (s8)0xFF,
-                        (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_ALL_NIGHT_MASK,
-                        (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1,
-                        (s16)-1),  // All Night Mask
+      [0x7E] =
+          ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::AllNightMask, 0x007E, 0x0265,
+                   (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_ALL_NIGHT_MASK,
+                   (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1,
+                   (s16)-1),  // All Night Mask
 
-      [0x7F] =
-          ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::BunnyHood,
-                   0x007F, 0x0103, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF,
-                   (s32)DrawGraphicItemID::DI_BUNNY_HOOD, (rnd::upgradeFunc)ItemUpgrade_None,
-                   ItemEffect_None, (s16)-1, (s16)-1),  // Bunny Hood
+      [0x7F] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::BunnyHood, 0x007F, 0x0103,
+                        (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_BUNNY_HOOD,
+                        (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1, (s16)-1),  // Bunny Hood
 
-      [0x80] =
-          ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::KeatonMask,
-                   0x0080, 0x0100, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF,
-                   (s32)DrawGraphicItemID::DI_KEATON_MASK, (rnd::upgradeFunc)ItemUpgrade_None,
-                   ItemEffect_None, (s16)-1, (s16)-1),  // Keaton Mask
+      [0x80] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::KeatonMask, 0x0080, 0x0100,
+                        (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_KEATON_MASK,
+                        (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1, (s16)-1),  // Keaton Mask
 
-      [0x81] =
-          ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::GaroMask,
-                   0x0081, 0x0209, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF,
-                   (s32)DrawGraphicItemID::DI_GARO_MASK, (rnd::upgradeFunc)ItemUpgrade_None,
-                   ItemEffect_None, (s16)-1, (s16)-1),  // Garo Mask
+      [0x81] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::GaroMask, 0x0081, 0x0209,
+                        (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_GARO_MASK,
+                        (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1, (s16)-1),  // Garo Mask
 
-      [0x82] =
-          ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::RomaniMask,
-                   0x0082, 0x021F, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF,
-                   (s32)DrawGraphicItemID::DI_ROMANIS_MASK, (rnd::upgradeFunc)ItemUpgrade_None,
-                   ItemEffect_None, (s16)-1, (s16)-1),  // Romani Mask
+      [0x82] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::RomaniMask, 0x0082, 0x021F,
+                        (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_ROMANIS_MASK,
+                        (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1, (s16)-1),  // Romani Mask
 
-      [0x83] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG,
-                        (u8)game::ItemId::CircusLeaderMask, 0x0083, 0x0259, (s8)0xFF, (s8)0xFF,
-                        (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_CIRCUS_LEADER_MASK,
-                        (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1,
+      [0x83] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::CircusLeaderMask, 0x0083,
+                        0x0259, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF,
+                        (s32)DrawGraphicItemID::DI_CIRCUS_LEADER_MASK, (rnd::upgradeFunc)ItemUpgrade_None,
+                        ItemEffect_None, (s16)-1,
                         (s16)-1),  // Circus Leader Mask
 
-      [0x84] =
-          ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::PostmanHat,
-                   0x0084, 0x0225, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF,
-                   (s32)DrawGraphicItemID::DI_POSTMANS_HAT, (rnd::upgradeFunc)ItemUpgrade_None,
-                   ItemEffect_None, (s16)-1, (s16)-1),  // Postman Hat
+      [0x84] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::PostmanHat, 0x0084, 0x0225,
+                        (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_POSTMANS_HAT,
+                        (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1, (s16)-1),  // Postman Hat
 
-      [0x85] =
-          ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::CoupleMask,
-                   0x0085, 0x0282, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF,
-                   (s32)DrawGraphicItemID::DI_COUPLES_MASK, (rnd::upgradeFunc)ItemUpgrade_None,
-                   ItemEffect_None, (s16)-1, (s16)-1),  // Couple's Mask
+      [0x85] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::CoupleMask, 0x0085, 0x0282,
+                        (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_COUPLES_MASK,
+                        (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1, (s16)-1),  // Couple's Mask
 
-      [0x86] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG,
-                        (u8)game::ItemId::GreatFairyMask, 0x0086, 0x020A, (s8)0xFF, (s8)0xFF,
-                        (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_GREAT_FAIRY_MASK,
-                        (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1,
-                        (s16)-1),  // Great Fairy's Mask
+      [0x86] =
+          ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::GreatFairyMask, 0x0086, 0x020A,
+                   (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_GREAT_FAIRY_MASK,
+                   (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1,
+                   (s16)-1),  // Great Fairy's Mask
 
-      [0x87] =
-          ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::GibdoMask,
-                   0x0087, 0x020B, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF,
-                   (s32)DrawGraphicItemID::DI_GIBDO_MASK, (rnd::upgradeFunc)ItemUpgrade_None,
-                   ItemEffect_None, (s16)-1, (s16)-1),  // Gibdo's Mask
+      [0x87] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::GibdoMask, 0x0087, 0x020B,
+                        (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_GIBDO_MASK,
+                        (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1, (s16)-1),  // Gibdo's Mask
 
       [0x88] =
-          ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::DonGeroMask,
-                   0x0088, 0x0266, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF,
-                   (s32)DrawGraphicItemID::DI_DON_GERO_MASK, (rnd::upgradeFunc)ItemUpgrade_None,
-                   ItemEffect_None, (s16)-1, (s16)-1),  // Don Gero's Mask
+          ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::DonGeroMask, 0x0088, 0x0266,
+                   (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_DON_GERO_MASK,
+                   (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1, (s16)-1),  // Don Gero's Mask
 
-      [0X89] =
-          ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::KamaroMask,
-                   0x0089, 0x027D, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF,
-                   (s32)DrawGraphicItemID::DI_KAMARO_MASK, (rnd::upgradeFunc)ItemUpgrade_None,
-                   ItemEffect_None, (s16)-1, (s16)-1),  // Kamaro's Mask
+      [0X89] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::KamaroMask, 0x0089, 0x027D,
+                        (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_KAMARO_MASK,
+                        (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1, (s16)-1),  // Kamaro's Mask
 
       [0x8A] =
-          ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::MaskOfTruth,
-                   0x008A, 0x0104, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF,
-                   (s32)DrawGraphicItemID::DI_MASK_OF_TRUTH, (rnd::upgradeFunc)ItemUpgrade_None,
-                   ItemEffect_None, (s16)-1, (s16)-1),  // Mask of Truth
+          ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::MaskOfTruth, 0x008A, 0x0104,
+                   (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_MASK_OF_TRUTH,
+                   (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1, (s16)-1),  // Mask of Truth
 
-      [0x8B] =
-          ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::StoneMask,
-                   0x008B, 0x0254, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF,
-                   (s32)DrawGraphicItemID::DI_STONE_MASK, (rnd::upgradeFunc)ItemUpgrade_None,
-                   ItemEffect_None, (s16)-1, (s16)-1),  // Stone Mask
+      [0x8B] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::StoneMask, 0x008B, 0x0254,
+                        (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_STONE_MASK,
+                        (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1, (s16)-1),  // Stone Mask
 
-      [0x8C] =
-          ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::BremenMask,
-                   0x008C, 0x025A, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF,
-                   (s32)DrawGraphicItemID::DI_BREMEN_MASK, (rnd::upgradeFunc)ItemUpgrade_None,
-                   ItemEffect_None, (s16)-1, (s16)-1),  // Bremen Mask
+      [0x8C] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::BremenMask, 0x008C, 0x025A,
+                        (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_BREMEN_MASK,
+                        (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1, (s16)-1),  // Bremen Mask
 
-      [0x8D] =
-          ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::BlastMask,
-                   0x008D, 0x026D, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF,
-                   (s32)DrawGraphicItemID::DI_BLAST_MASK, (rnd::upgradeFunc)ItemUpgrade_None,
-                   ItemEffect_None, (s16)-1, (s16)-1),  // Blast Mask
+      [0x8D] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::BlastMask, 0x008D, 0x026D,
+                        (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_BLAST_MASK,
+                        (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1, (s16)-1),  // Blast Mask
 
-      [0x8E] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG,
-                        (u8)game::ItemId::MaskOfScents, 0x008E, 0x027E, (s8)0xFF, (s8)0xFF,
-                        (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_MASK_OF_SCENTS,
-                        (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1,
-                        (s16)-1),  // Mask Of Scents
+      [0x8E] =
+          ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::MaskOfScents, 0x008E, 0x027E,
+                   (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_MASK_OF_SCENTS,
+                   (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1,
+                   (s16)-1),  // Mask Of Scents
 
-      [0x8F] =
-          ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::KafeiMask,
-                   0x008F, 0x0258, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF,
-                   (s32)DrawGraphicItemID::DI_KAFEI_MASK, (rnd::upgradeFunc)ItemUpgrade_None,
-                   ItemEffect_None, (s16)-1, (s16)-1),  // Kafei Mask
+      [0x8F] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::KafeiMask, 0x008F, 0x0258,
+                        (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_KAFEI_MASK,
+                        (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1, (s16)-1),  // Kafei Mask
 
-      [0x90] = ITEM_ROW((u32)GetItemID::GI_RUPEE_BLUE, ChestType::DECORATED_SMALL,
-                        (u8)game::ItemId::SmallKey, 0x003C, 0x00086, (s8)0xFF, (s8)0xFF, (s8)0xFF,
-                        (s8)0xFF, (s8)0xFF, 0xFF, (rnd::upgradeFunc)ItemUpgrade_None,
-                        ItemEffect_GiveSmallKey, (s16)2, (s16)-1),  // Small Key (Great Bay)
+      [0x90] =
+          ITEM_ROW((u32)GetItemID::GI_RUPEE_BLUE, ChestType::DECORATED_SMALL, (u8)game::ItemId::SmallKey, 0x003C,
+                   0x00086, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, 0xFF, (rnd::upgradeFunc)ItemUpgrade_None,
+                   ItemEffect_GiveSmallKey, (s16)2, (s16)-1),  // Small Key (Great Bay)
 
       // The following bottle items either give one bottle if you do not have one, or refills any
       // bottle if you do have an empty one. Essentially acts as if you caught something in a
       // bottle.
-      [0x91] = ITEM_ROW(
-          (u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::ChateauRomaniFill,
-          0x0091, 0x0227, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF,
-          (s32)DrawGraphicItemID::DI_BOTTLE_CHATEAU_ROMANI, (rnd::upgradeFunc)ItemUpgrade_None,
-          ItemEffect_None, (s16)-1, (s16)-1),  // Cheateu Refill
+      [0x91] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::ChateauRomaniFill, 0x0091,
+                        0x0227, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF,
+                        (s32)DrawGraphicItemID::DI_BOTTLE_CHATEAU_ROMANI, (rnd::upgradeFunc)ItemUpgrade_None,
+                        ItemEffect_None, (s16)-1, (s16)-1),  // Cheateu Refill
 
-      [0x92] =
-          ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::MilkFill,
-                   0x0092, 0x00B6, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF,
-                   (s32)DrawGraphicItemID::DI_BOTTLE_MILK, (rnd::upgradeFunc)ItemUpgrade_None,
-                   ItemEffect_None, (s16)-1, (s16)-1),  // Milk Refill
+      [0x92] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::MilkFill, 0x0092, 0x00B6,
+                        (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_BOTTLE_MILK,
+                        (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1, (s16)-1),  // Milk Refill
 
-      [0x93] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG,
-                        (u8)game::ItemId::GoldDustFill, 0x0093, 0x001E8, (s8)0xFF, (s8)0xFF,
-                        (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_BOTTLE_GOLD_DUST,
-                        (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1,
-                        (s16)-1),  // Gold Dust Refill
+      [0x93] =
+          ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::GoldDustFill, 0x0093, 0x001E8,
+                   (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_BOTTLE_GOLD_DUST,
+                   (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1,
+                   (s16)-1),  // Gold Dust Refill
 
-      [0x94] = ITEM_ROW(
-          (u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::MysteryMilkFill,
-          0x00CE, 0x00B6, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF,
-          (s32)DrawGraphicItemID::DI_BOTTLE_MYSTERY_MILK, (rnd::upgradeFunc)ItemUpgrade_None,
-          ItemEffect_None, (s16)-1, (s16)-1),  // Mystery Milk Refill
+      [0x94] =
+          ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::MysteryMilkFill, 0x00CE, 0x00B6,
+                   (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_BOTTLE_MYSTERY_MILK,
+                   (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1, (s16)-1),  // Mystery Milk Refill
 
-      [0x95] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG,
-                        (u8)game::ItemId::SeahorseFill, 0x0095, 0x001F0, (s8)0xFF, (s8)0xFF,
-                        (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_BOTTLE_SEAHORSE,
-                        (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1,
-                        (s16)-1),  // Seahorse Refill
+      [0x95] =
+          ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::SeahorseFill, 0x0095, 0x001F0,
+                   (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_BOTTLE_SEAHORSE,
+                   (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1,
+                   (s16)-1),  // Seahorse Refill
 
       // TODO: Trade quest items
-      [0x96] =
-          ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::MoonTear,
-                   0x0096, 0x01B1, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF,
-                   (s32)DrawGraphicItemID::DI_MOONS_TEAR, (rnd::upgradeFunc)ItemUpgrade_None,
-                   ItemEffect_None, (s16)-1, (s16)-1),  // Moon's Tear
+      [0x96] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::MoonTear, 0x0096, 0x01B1,
+                        (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_MOONS_TEAR,
+                        (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1, (s16)-1),  // Moon's Tear
 
-      [0x97] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG,
-                        (u8)game::ItemId::LandTitleDeed, 0x0097, 0x01B2, (s8)0xFF, (s8)0xFF,
-                        (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_TOWN_TITLE_DEED,
-                        (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1,
-                        (s16)-1),  // Land Title Deed
+      [0x97] =
+          ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::LandTitleDeed, 0x0097, 0x01B2,
+                   (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_TOWN_TITLE_DEED,
+                   (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1,
+                   (s16)-1),  // Land Title Deed
 
-      [0x98] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG,
-                        (u8)game::ItemId::SwampTitleDeed, 0x0098, 0x01B2, (s8)0xFF, (s8)0xFF,
-                        (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_SWAMP_TITLE_DEED,
-                        (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1,
-                        (s16)-1),  // Swamp Title Deed
+      [0x98] =
+          ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::SwampTitleDeed, 0x0098, 0x01B2,
+                   (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_SWAMP_TITLE_DEED,
+                   (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1,
+                   (s16)-1),  // Swamp Title Deed
 
-      [0x99] = ITEM_ROW(
-          (u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::MountainTitleDeed,
-          0x0099, 0x01B2, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF,
-          (s32)DrawGraphicItemID::DI_MOUNTAIN_TITLE_DEED, (rnd::upgradeFunc)ItemUpgrade_None,
-          ItemEffect_None, (s16)-1, (s16)-1),  // Mountain Title Deed
+      [0x99] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::MountainTitleDeed, 0x0099,
+                        0x01B2, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF,
+                        (s32)DrawGraphicItemID::DI_MOUNTAIN_TITLE_DEED, (rnd::upgradeFunc)ItemUpgrade_None,
+                        ItemEffect_None, (s16)-1, (s16)-1),  // Mountain Title Deed
 
-      [0x9A] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG,
-                        (u8)game::ItemId::OceanTitleDeed, 0x009A, 0x01B2, (s8)0xFF, (s8)0xFF,
-                        (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_OCEAN_TITLE_DEED,
-                        (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1,
-                        (s16)-1),  // Ocean Title Deed
+      [0x9A] =
+          ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::OceanTitleDeed, 0x009A, 0x01B2,
+                   (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_OCEAN_TITLE_DEED,
+                   (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1,
+                   (s16)-1),  // Ocean Title Deed
 
-      [0x9B] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG,
-                        (u8)game::ItemId::GreatFairySword, 0x009B, 0x001FB, (s8)0xFF, (s8)0xFF,
-                        (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_GREAT_FAIRY_SWORD,
-                        (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1,
+      [0x9B] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::GreatFairySword, 0x009B,
+                        0x001FB, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF,
+                        (s32)DrawGraphicItemID::DI_GREAT_FAIRY_SWORD, (rnd::upgradeFunc)ItemUpgrade_None,
+                        ItemEffect_None, (s16)-1,
                         (s16)-1),  // Purchasing Great Fairy Sword
 
       [0x9C] =
-          ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::KokiriSword,
-                   0x009C, 0x00148, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF,
-                   (s32)DrawGraphicItemID::DI_KOKIRI_SWORD, (rnd::upgradeFunc)ItemUpgrade_None,
-                   ItemEffect_None, (s16)-1, (s16)-1),  // Purchasing Kokiri Sword
+          ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::KokiriSword, 0x009C, 0x00148,
+                   (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_KOKIRI_SWORD,
+                   (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1, (s16)-1),  // Purchasing Kokiri Sword
 
       [0x9D] =
-          ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::RazorSword,
-                   0x009D, 0x001F9, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF,
-                   (s32)DrawGraphicItemID::DI_RAZOR_SWORD, (rnd::upgradeFunc)ItemUpgrade_None,
-                   ItemEffect_None, (s16)-1, (s16)-1),  // Purchasing Razor Sword
+          ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::RazorSword, 0x009D, 0x001F9,
+                   (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_RAZOR_SWORD,
+                   (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1, (s16)-1),  // Purchasing Razor Sword
 
       [0x9E] =
-          ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::GildedSword,
-                   0x009E, 0x001FA, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF,
-                   (s32)DrawGraphicItemID::DI_GILDED_SWORD, (rnd::upgradeFunc)ItemUpgrade_None,
-                   ItemEffect_None, (s16)-1, (s16)-1),  // Purchasing Gilded Sword
+          ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::GildedSword, 0x009E, 0x001FA,
+                   (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_GILDED_SWORD,
+                   (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1, (s16)-1),  // Purchasing Gilded Sword
 
       [0x9F] =
-          ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::HeroShield,
-                   0x009F, 0x000B3, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF,
-                   (s32)DrawGraphicItemID::DI_HERO_SHIELD, (rnd::upgradeFunc)ItemUpgrade_None,
-                   ItemEffect_None, (s16)-1, (s16)-1),  // Purchasing Hero Shield
+          ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::HeroShield, 0x009F, 0x000B3,
+                   (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_HERO_SHIELD,
+                   (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1, (s16)-1),  // Purchasing Hero Shield
 
-      [0xA0] =
-          ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::RoomKey,
-                   0x00A0, 0x020F, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF,
-                   (s32)DrawGraphicItemID::DI_ROOM_KEY, (rnd::upgradeFunc)ItemUpgrade_None,
-                   ItemEffect_None, (s16)-1, (s16)-1),  // Room Key
+      [0xA0] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::RoomKey, 0x00A0, 0x020F,
+                        (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_ROOM_KEY,
+                        (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1, (s16)-1),  // Room Key
 
-      [0xA1] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG,
-                        (u8)game::ItemId::LetterToMama, 0x00A1, 0x0245, (s8)0xFF, (s8)0xFF,
-                        (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_MAMAS_LETTER,
-                        (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1,
-                        (s16)-1),  // Letter To Mama
+      [0xA1] =
+          ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::LetterToMama, 0x00A1, 0x0245,
+                   (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_MAMAS_LETTER,
+                   (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1,
+                   (s16)-1),  // Letter To Mama
 
-      [0xA2] = ITEM_ROW((u32)GetItemID::GI_RUPEE_BLUE, ChestType::DECORATED_SMALL,
-                        (u8)game::ItemId::SmallKey, 0x003C, 0x00086, (s8)0xFF, (s8)0xFF, (s8)0xFF,
-                        (s8)0xFF, (s8)0xFF, 0xFF, (rnd::upgradeFunc)ItemUpgrade_None,
-                        ItemEffect_GiveSmallKey, (s16)3, (s16)-1),  // Small Key (Stone Tower)
+      [0xA2] =
+          ITEM_ROW((u32)GetItemID::GI_RUPEE_BLUE, ChestType::DECORATED_SMALL, (u8)game::ItemId::SmallKey, 0x003C,
+                   0x00086, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, 0xFF, (rnd::upgradeFunc)ItemUpgrade_None,
+                   ItemEffect_GiveSmallKey, (s16)3, (s16)-1),  // Small Key (Stone Tower)
 
-      [0xA3] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::DECORATED_BIG,
-                        (u8)game::ItemId::BossKey, 0x003D, 0x00092, (s8)0xFF, (s8)0xFF, (s8)0xFF,
-                        (s8)0xFF, (s8)0xFF, 0xFF, (rnd::upgradeFunc)ItemUpgrade_None,
-                        ItemEffect_GiveDungeonItem, (s16)1, (s16)0),  // Boss Key (Woodfall)
+      [0xA3] =
+          ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::DECORATED_BIG, (u8)game::ItemId::BossKey, 0x003D, 0x00092,
+                   (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, 0xFF, (rnd::upgradeFunc)ItemUpgrade_None,
+                   ItemEffect_GiveDungeonItem, (s16)1, (s16)0),  // Boss Key (Woodfall)
 
-      [0xA4] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::DECORATED_BIG,
-                        (u8)game::ItemId::BossKey, 0x003D, 0x00092, (s8)0xFF, (s8)0xFF, (s8)0xFF,
-                        (s8)0xFF, (s8)0xFF, 0xFF, (rnd::upgradeFunc)ItemUpgrade_None,
-                        ItemEffect_GiveDungeonItem, (s16)1, (s16)1),  // Boss Key (Snowhead)
+      [0xA4] =
+          ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::DECORATED_BIG, (u8)game::ItemId::BossKey, 0x003D, 0x00092,
+                   (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, 0xFF, (rnd::upgradeFunc)ItemUpgrade_None,
+                   ItemEffect_GiveDungeonItem, (s16)1, (s16)1),  // Boss Key (Snowhead)
 
-      [0xA5] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::DECORATED_BIG,
-                        (u8)game::ItemId::BossKey, 0x003D, 0x00092, (s8)0xFF, (s8)0xFF, (s8)0xFF,
-                        (s8)0xFF, (s8)0xFF, 0xFF, (rnd::upgradeFunc)ItemUpgrade_None,
-                        ItemEffect_GiveDungeonItem, (s16)1, (s16)2),  // Boss Key (Great Bay)
+      [0xA5] =
+          ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::DECORATED_BIG, (u8)game::ItemId::BossKey, 0x003D, 0x00092,
+                   (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, 0xFF, (rnd::upgradeFunc)ItemUpgrade_None,
+                   ItemEffect_GiveDungeonItem, (s16)1, (s16)2),  // Boss Key (Great Bay)
 
-      [0xA6] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::DECORATED_BIG,
-                        (u8)game::ItemId::BossKey, 0x003D, 0x00092, (s8)0xFF, (s8)0xFF, (s8)0xFF,
-                        (s8)0xFF, (s8)0xFF, 0xFF, (rnd::upgradeFunc)ItemUpgrade_None,
-                        ItemEffect_GiveDungeonItem, (s16)1, (s16)3),  // Boss Key (Stone Tower)
+      [0xA6] =
+          ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::DECORATED_BIG, (u8)game::ItemId::BossKey, 0x003D, 0x00092,
+                   (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, 0xFF, (rnd::upgradeFunc)ItemUpgrade_None,
+                   ItemEffect_GiveDungeonItem, (s16)1, (s16)3),  // Boss Key (Stone Tower)
 
-      [0xA7] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::DECORATED_BIG,
-                        (u8)game::ItemId::Compass, 0x003F, 0x00091, (s8)0xFF, (s8)0xFF, (s8)0xFF,
-                        (s8)0xFF, (s8)0xFF, 0xFF, (rnd::upgradeFunc)ItemUpgrade_None,
-                        ItemEffect_GiveDungeonItem, (s16)2, (s16)0),  // Compass (Woodfall)
+      [0xA7] =
+          ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::DECORATED_BIG, (u8)game::ItemId::Compass, 0x003F, 0x00091,
+                   (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, 0xFF, (rnd::upgradeFunc)ItemUpgrade_None,
+                   ItemEffect_GiveDungeonItem, (s16)2, (s16)0),  // Compass (Woodfall)
 
-      [0xA8] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::DECORATED_BIG,
-                        (u8)game::ItemId::Compass, 0x003F, 0x00091, (s8)0xFF, (s8)0xFF, (s8)0xFF,
-                        (s8)0xFF, (s8)0xFF, 0xFF, (rnd::upgradeFunc)ItemUpgrade_None,
-                        ItemEffect_GiveDungeonItem, (s16)2, (s16)1),  // Compass (Snowhead)
+      [0xA8] =
+          ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::DECORATED_BIG, (u8)game::ItemId::Compass, 0x003F, 0x00091,
+                   (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, 0xFF, (rnd::upgradeFunc)ItemUpgrade_None,
+                   ItemEffect_GiveDungeonItem, (s16)2, (s16)1),  // Compass (Snowhead)
 
       [0xA9] =
-          ITEM_ROW((u32)GetItemID::GI_RUPEE_BLUE, ChestType::WOODEN_SMALL, (u8)game::ItemId::Bottle,
-                   0x0090, 0x0009E, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF,
-                   (s32)DrawGraphicItemID::DI_EMPTY_BOTTLE, (rnd::upgradeFunc)ItemUpgrade_None,
-                   ItemEffect_None, (s16)-1, (s16)-1),  // Purhcasing Bottle
+          ITEM_ROW((u32)GetItemID::GI_RUPEE_BLUE, ChestType::WOODEN_SMALL, (u8)game::ItemId::Bottle, 0x0090, 0x0009E,
+                   (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_EMPTY_BOTTLE,
+                   (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1, (s16)-1),  // Purhcasing Bottle
 
-      [0xAA] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG,
-                        (u8)game::ItemId::LetterToKafei, 0x00AA, 0x0210, (s8)0xFF, (s8)0xFF,
-                        (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_LETTER_TO_KAFEI,
-                        (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1,
-                        (s16)-1),  // Letter To Kafei
+      [0xAA] =
+          ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::LetterToKafei, 0x00AA, 0x0210,
+                   (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_LETTER_TO_KAFEI,
+                   (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1,
+                   (s16)-1),  // Letter To Kafei
 
-      [0xAB] = ITEM_ROW(
-          (u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::PendantOfMemories,
-          0x00AB, 0x0215, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF,
-          (s32)DrawGraphicItemID::DI_PENDANT_OF_MEMORIES, (rnd::upgradeFunc)ItemUpgrade_None,
-          ItemEffect_None, (s16)-1, (s16)-1),  // Pendant Of Memories
+      [0xAB] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::PendantOfMemories, 0x00AB,
+                        0x0215, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF,
+                        (s32)DrawGraphicItemID::DI_PENDANT_OF_MEMORIES, (rnd::upgradeFunc)ItemUpgrade_None,
+                        ItemEffect_None, (s16)-1, (s16)-1),  // Pendant Of Memories
 
-      [0xAC] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::DECORATED_BIG,
-                        (u8)game::ItemId::Compass, 0x003F, 0x00091, (s8)0xFF, (s8)0xFF, (s8)0xFF,
-                        (s8)0xFF, (s8)0xFF, 0xFF, (rnd::upgradeFunc)ItemUpgrade_None,
-                        ItemEffect_GiveDungeonItem, (s16)2, (s16)2),  // Compass (Great Bay)
+      [0xAC] =
+          ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::DECORATED_BIG, (u8)game::ItemId::Compass, 0x003F, 0x00091,
+                   (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, 0xFF, (rnd::upgradeFunc)ItemUpgrade_None,
+                   ItemEffect_GiveDungeonItem, (s16)2, (s16)2),  // Compass (Great Bay)
 
-      [0xAD] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::DECORATED_BIG,
-                        (u8)game::ItemId::Compass, 0x003F, 0x00091, (s8)0xFF, (s8)0xFF, (s8)0xFF,
-                        (s8)0xFF, (s8)0xFF, 0xFF, (rnd::upgradeFunc)ItemUpgrade_None,
-                        ItemEffect_GiveDungeonItem, (s16)2, (s16)3),  // Compass (Stone Tower)
+      [0xAD] =
+          ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::DECORATED_BIG, (u8)game::ItemId::Compass, 0x003F, 0x00091,
+                   (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, 0xFF, (rnd::upgradeFunc)ItemUpgrade_None,
+                   ItemEffect_GiveDungeonItem, (s16)2, (s16)3),  // Compass (Stone Tower)
 
-      [0xAE] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::DECORATED_BIG, (u8)game::ItemId::Map,
-                        0x003E, 0x000A0, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, 0xFF,
-                        (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_GiveDungeonItem, (s16)3,
+      [0xAE] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::DECORATED_BIG, (u8)game::ItemId::Map, 0x003E, 0x000A0,
+                        (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, 0xFF, (rnd::upgradeFunc)ItemUpgrade_None,
+                        ItemEffect_GiveDungeonItem, (s16)3,
                         (s16)0),  // Map (Woodfall)
 
-      [0xAF] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::DECORATED_BIG, (u8)game::ItemId::Map,
-                        0x003E, 0x000A0, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, 0xFF,
-                        (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_GiveDungeonItem, (s16)3,
+      [0xAF] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::DECORATED_BIG, (u8)game::ItemId::Map, 0x003E, 0x000A0,
+                        (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, 0xFF, (rnd::upgradeFunc)ItemUpgrade_None,
+                        ItemEffect_GiveDungeonItem, (s16)3,
                         (s16)1),  // Map (Snowhead)
 
-      [0xB0] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::DECORATED_BIG, (u8)game::ItemId::Map,
-                        0x003E, 0x000A0, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, 0xFF,
-                        (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_GiveDungeonItem, (s16)3,
+      [0xB0] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::DECORATED_BIG, (u8)game::ItemId::Map, 0x003E, 0x000A0,
+                        (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, 0xFF, (rnd::upgradeFunc)ItemUpgrade_None,
+                        ItemEffect_GiveDungeonItem, (s16)3,
                         (s16)2),  // Map (Great Bay)
 
-      [0xB1] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::DECORATED_BIG, (u8)game::ItemId::Map,
-                        0x003E, 0x000A0, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, 0xFF,
-                        (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_GiveDungeonItem, (s16)3,
+      [0xB1] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::DECORATED_BIG, (u8)game::ItemId::Map, 0x003E, 0x000A0,
+                        (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, 0xFF, (rnd::upgradeFunc)ItemUpgrade_None,
+                        ItemEffect_GiveDungeonItem, (s16)3,
                         (s16)3),  // Map (Stone Tower)
 
-      [0xB2] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::None,
-                        0x000CB, 0x00096, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, 0xFF,
-                        (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_GiveDoubleDefense, (s16)3,
+      [0xB2] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::None, 0x000CB, 0x00096,
+                        (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, 0xFF, (rnd::upgradeFunc)ItemUpgrade_None,
+                        ItemEffect_GiveDoubleDefense, (s16)3,
                         (s16)3),  // Double Defense.
 
-      [0xB3] =
-          ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG,
-                   (u8)game::ItemId::SmallMagicAccumulator, 0x000C8, 0x000A4, (s8)0xFF, (s8)0xFF,
-                   (s8)0xFF, (s8)0xFF, (s8)0xFF, 0xFF, (rnd::upgradeFunc)ItemUpgrade_None,
-                   ItemEffect_GiveMagic, (s16)-1, (s16)-1),  // Small Magic
+      [0xB3] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::SmallMagicAccumulator,
+                        0x000C8, 0x000A4, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, 0xFF,
+                        (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_GiveMagic, (s16)-1, (s16)-1),  // Small Magic
 
-      [0xB4] = ITEM_ROW((u32)GetItemID::GI_RUPEE_BLUE, ChestType::WOODEN_SMALL,
-                        (u8)game::ItemId::MapUnused, 0x00B4, 0x024D, (s8)0xFF, (s8)0xFF, (s8)0xFF,
-                        (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_TOWN_MAP,
+      [0xB4] = ITEM_ROW((u32)GetItemID::GI_RUPEE_BLUE, ChestType::WOODEN_SMALL, (u8)game::ItemId::MapUnused, 0x00B4,
+                        0x024D, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_TOWN_MAP,
                         (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1,
                         (s16)-1),  // Map of Clocktown
 
-      [0xB5] = ITEM_ROW((u32)GetItemID::GI_RUPEE_BLUE, ChestType::WOODEN_SMALL,
-                        (u8)game::ItemId::MapUnused, 0x00B5, 0x024D, (s8)0xFF, (s8)0xFF, (s8)0xFF,
-                        (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_TOWN_MAP,
+      [0xB5] = ITEM_ROW((u32)GetItemID::GI_RUPEE_BLUE, ChestType::WOODEN_SMALL, (u8)game::ItemId::MapUnused, 0x00B5,
+                        0x024D, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_TOWN_MAP,
                         (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1,
                         (s16)-1),  // Map of Woodfall
 
-      [0xB6] = ITEM_ROW((u32)GetItemID::GI_RUPEE_BLUE, ChestType::WOODEN_SMALL,
-                        (u8)game::ItemId::MapUnused, 0x00B6, 0x024D, (s8)0xFF, (s8)0xFF, (s8)0xFF,
-                        (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_TOWN_MAP,
+      [0xB6] = ITEM_ROW((u32)GetItemID::GI_RUPEE_BLUE, ChestType::WOODEN_SMALL, (u8)game::ItemId::MapUnused, 0x00B6,
+                        0x024D, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_TOWN_MAP,
                         (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1,
                         (s16)-1),  // Map of Snowhead
 
-      [0xB7] = ITEM_ROW((u32)GetItemID::GI_RUPEE_BLUE, ChestType::WOODEN_SMALL,
-                        (u8)game::ItemId::MapUnused, 0x00B7, 0x024D, (s8)0xFF, (s8)0xFF, (s8)0xFF,
-                        (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_TOWN_MAP,
+      [0xB7] = ITEM_ROW((u32)GetItemID::GI_RUPEE_BLUE, ChestType::WOODEN_SMALL, (u8)game::ItemId::MapUnused, 0x00B7,
+                        0x024D, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_TOWN_MAP,
                         (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1,
                         (s16)-1),  // Map of Romani Ranch
 
-      [0xB8] = ITEM_ROW((u32)GetItemID::GI_RUPEE_BLUE, ChestType::WOODEN_SMALL,
-                        (u8)game::ItemId::MapUnused, 0x00B8, 0x024D, (s8)0xFF, (s8)0xFF, (s8)0xFF,
-                        (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_TOWN_MAP,
+      [0xB8] = ITEM_ROW((u32)GetItemID::GI_RUPEE_BLUE, ChestType::WOODEN_SMALL, (u8)game::ItemId::MapUnused, 0x00B8,
+                        0x024D, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_TOWN_MAP,
                         (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1,
                         (s16)-1),  // Map of Great Bay
 
-      [0xB9] = ITEM_ROW((u32)GetItemID::GI_RUPEE_BLUE, ChestType::WOODEN_SMALL,
-                        (u8)game::ItemId::MapUnused, 0x00B9, 0x024D, (s8)0xFF, (s8)0xFF, (s8)0xFF,
-                        (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_TOWN_MAP,
+      [0xB9] = ITEM_ROW((u32)GetItemID::GI_RUPEE_BLUE, ChestType::WOODEN_SMALL, (u8)game::ItemId::MapUnused, 0x00B9,
+                        0x024D, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_TOWN_MAP,
                         (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1,
                         (s16)-1),  // Map of Stone Tower
 
-      [0xBA] = ITEM_ROW((u32)GetItemID::GI_RUPEE_BLUE, ChestType::WOODEN_SMALL,
-                        (u8)game::ItemId::FishingPass, 0x00CF, 0x029B, (s8)0xFF, (s8)0xFF, (s8)0xFF,
-                        (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_FISHING_PASS,
-                        (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1,
-                        (s16)-1),  // Fishing Pass
+      [0xBA] =
+          ITEM_ROW((u32)GetItemID::GI_RUPEE_BLUE, ChestType::WOODEN_SMALL, (u8)game::ItemId::FishingPass, 0x00CF,
+                   0x029B, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_FISHING_PASS,
+                   (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1,
+                   (s16)-1),  // Fishing Pass
 
       // Custom Items begin here
       // TODO: Custom text for sword?

--- a/code/source/rnd/item_upgrade.cpp
+++ b/code/source/rnd/item_upgrade.cpp
@@ -44,6 +44,9 @@ namespace rnd {
   }
 
   GetItemID ItemUpgrade_Magic(game::SaveData* saveCtx, GetItemID GetItemId) {
+#if defined ENABLE_DEBUG || defined DEBUG_PRINT
+    rnd::util::Print("%s: Our num upgrades is %i", __func__, saveCtx->player.magic_num_upgrades);
+#endif
     switch (saveCtx->player.magic_acquired) {
     case 0:
       return (GetItemID)0xB3;

--- a/code/source/rnd/item_upgrade.cpp
+++ b/code/source/rnd/item_upgrade.cpp
@@ -44,9 +44,6 @@ namespace rnd {
   }
 
   GetItemID ItemUpgrade_Magic(game::SaveData* saveCtx, GetItemID GetItemId) {
-#if defined ENABLE_DEBUG || defined DEBUG_PRINT
-    rnd::util::Print("%s: Our num upgrades is %i", __func__, saveCtx->player.magic_num_upgrades);
-#endif
     switch (saveCtx->player.magic_acquired) {
     case 0:
       return (GetItemID)0xB3;

--- a/code/source/rnd/link.cpp
+++ b/code/source/rnd/link.cpp
@@ -12,8 +12,7 @@ namespace rnd::link {
                      GetContext().use_fast_swim);
 #endif
     // Toggle fast swim with D-Pad Up/Down or ZL
-    if (input.new_buttons.IsOneSet(game::pad::Button::Up, game::pad::Button::Down,
-                                   game::pad::Button::ZL)) {
+    if (input.new_buttons.IsOneSet(game::pad::Button::Up, game::pad::Button::Down, game::pad::Button::ZL)) {
       GetContext().use_fast_swim ^= true;
     }
 

--- a/code/source/rnd/ocarina.cpp
+++ b/code/source/rnd/ocarina.cpp
@@ -18,8 +18,7 @@ namespace rnd {
     const auto set_ocarina_fadeout = util::GetPointer<void(int zero, int duration)>(0x4FE0BC);
     set_ocarina_fadeout(0, fade_durations[u8(gctx->GetPlayerActor()->active_form)]);
 
-    const auto set_ocarina_mode =
-        util::GetPointer<void(game::ui::MessageWindow*, int mode)>(0x1D1A18);
+    const auto set_ocarina_mode = util::GetPointer<void(game::ui::MessageWindow*, int mode)>(0x1D1A18);
     set_ocarina_mode(window, 1);
 
     // Disable BGM fadeout

--- a/code/source/rnd/savefile.cpp
+++ b/code/source/rnd/savefile.cpp
@@ -20,8 +20,8 @@ namespace rnd {
     u8 isNewFile = saveData.has_completed_intro;
     if (isNewFile == 0) {
 #if defined ENABLE_DEBUG || defined DEBUG_PRINT
-      rnd::util::Print("%s: Initing save file. Our save index is %u\nAre we a new file? %#04x\n",
-                       __func__, comData.save_idx, saveData.has_completed_intro);
+      rnd::util::Print("%s: Initing save file. Our save index is %u\nAre we a new file? %#04x\n", __func__,
+                       comData.save_idx, saveData.has_completed_intro);
 #endif
 #ifdef ENABLE_DEBUG
       saveData.equipment.sword_shield.sword = game::SwordType::GildedSword;
@@ -259,8 +259,7 @@ namespace rnd {
       saveData.bomberscode[2] = 0x01;
       saveData.bomberscode[3] = 0x01;
       saveData.bomberscode[4] = 0x01;
-      saveData.temp_event_flag_bundle1.bomber_open_hideout =
-          1;  // Currently gets reset by Song of time
+      saveData.temp_event_flag_bundle1.bomber_open_hideout = 1;  // Currently gets reset by Song of time
     }
 
     // Game uses an inventory check to determine whether you can
@@ -334,8 +333,7 @@ namespace rnd {
     game::EquipmentData& equipmentData = game::GetCommonData().save.equipment;
     game::SaveData& saveData = game::GetCommonData().save;
     // give maps and compasses
-    if (gSettingsContext.mapsAndCompasses ==
-        (u8)MapsAndCompassesSetting::MAPSANDCOMPASSES_ANY_DUNGEON) {
+    if (gSettingsContext.mapsAndCompasses == (u8)MapsAndCompassesSetting::MAPSANDCOMPASSES_ANY_DUNGEON) {
       inventoryData.woodfall_dungeon_items.map = 1;
       inventoryData.woodfall_dungeon_items.compass = 1;
       inventoryData.snowhead_dungeon_items.map = 1;
@@ -345,8 +343,7 @@ namespace rnd {
       inventoryData.stone_tower_dungeon_items.map = 1;
       inventoryData.stone_tower_dungeon_items.compass = 1;
     }
-    if (gSettingsContext.mapsAndCompasses ==
-        (u8)MapsAndCompassesSetting::MAPSANDCOMPASSES_OVERWORLD) {
+    if (gSettingsContext.mapsAndCompasses == (u8)MapsAndCompassesSetting::MAPSANDCOMPASSES_OVERWORLD) {
       SaveFile_FillOverWorldMapData();
     }
 
@@ -537,8 +534,8 @@ namespace rnd {
     gExtSaveData.version = EXTSAVEDATA_VERSION;  // Do not change this line
     gExtSaveData.isNewFile = 1;
 #if defined ENABLE_DEBUG || defined DEBUG_PRINT
-    util::Print("%s: Size of isNewFile and version is %u and %u", __func__,
-                sizeof(gExtSaveData.isNewFile), sizeof(gExtSaveData.version));
+    util::Print("%s: Size of isNewFile and version is %u and %u", __func__, sizeof(gExtSaveData.isNewFile),
+                sizeof(gExtSaveData.version));
 #endif
     // TODO: BitField for event flags instead?
     // memset(&gExtSaveData.extInf, 0, sizeof(gExtSaveData.extInf));
@@ -593,8 +590,7 @@ namespace rnd {
 #if defined ENABLE_DEBUG || defined DEBUG_PRINT
     rnd::util::Print("%s: Is New file? %u\n", __func__, newSave);
 #endif
-    if (fileSize != sizeof(gExtSaveData) || version != EXTSAVEDATA_VERSION ||
-        gExtSaveData.isNewFile == 1) {
+    if (fileSize != sizeof(gExtSaveData) || version != EXTSAVEDATA_VERSION || gExtSaveData.isNewFile == 1) {
       extDataClose(fileHandle);
       extDataDeleteFile(fsa, path);
       SaveFile_InitExtSaveData(saveNumber);

--- a/code/source/rnd/savefile.cpp
+++ b/code/source/rnd/savefile.cpp
@@ -536,8 +536,10 @@ namespace rnd {
 #endif
     gExtSaveData.version = EXTSAVEDATA_VERSION;  // Do not change this line
     gExtSaveData.isNewFile = 1;
+#if defined ENABLE_DEBUG || defined DEBUG_PRINT
     util::Print("%s: Size of isNewFile and version is %u and %u", __func__,
                 sizeof(gExtSaveData.isNewFile), sizeof(gExtSaveData.version));
+#endif
     // TODO: BitField for event flags instead?
     // memset(&gExtSaveData.extInf, 0, sizeof(gExtSaveData.extInf));
     memset(&gExtSaveData.aromaGivenItem, 0, sizeof(gExtSaveData.aromaGivenItem));
@@ -565,7 +567,9 @@ namespace rnd {
     FS_Archive fsa;
     Handle fileHandle = extInitFileHandle();
     if (R_FAILED(res = extDataMount(&fsa))) {
+#if defined ENABLE_DEBUG || defined DEBUG_PRINT
       rnd::util::Print("%s: Failed to mount ext data.\n", __func__);
+#endif
       SaveFile_InitExtSaveData(saveNumber);
       SaveFile_SaveExtSaveData();
       return;
@@ -586,7 +590,9 @@ namespace rnd {
     FSFILE_GetSize(fileHandle, &fileSize);
     extDataReadFile(fileHandle, &version, 0, sizeof(version));
     extDataReadFile(fileHandle, &newSave, 8, sizeof(newSave));
+#if defined ENABLE_DEBUG || defined DEBUG_PRINT
     rnd::util::Print("%s: Is New file? %u\n", __func__, newSave);
+#endif
     if (fileSize != sizeof(gExtSaveData) || version != EXTSAVEDATA_VERSION ||
         gExtSaveData.isNewFile == 1) {
       extDataClose(fileHandle);
@@ -604,7 +610,9 @@ namespace rnd {
     extDataClose(fileHandle);
   }
   extern "C" void SaveFile_SaveExtSaveData() {
+#if defined ENABLE_DEBUG || defined DEBUG_PRINT
     rnd::util::Print("%s: Saving extdata.\n", __func__);
+#endif
     game::CommonData& comData = game::GetCommonData();
     char path[] = "/0.bin";
 
@@ -618,7 +626,9 @@ namespace rnd {
     path[1] = comData.save_idx + '0';
 
     extDataWriteFileDirectly(fsa, path, &gExtSaveData, 0, sizeof(gExtSaveData));
+#if defined ENABLE_DEBUG || defined DEBUG_PRINT
     util::Print("%s: Unmounting now...\n", __func__);
+#endif
     extDataUnmount(fsa);
   }
 

--- a/code/source/rnd/settings.cpp
+++ b/code/source/rnd/settings.cpp
@@ -58,10 +58,8 @@ namespace rnd {
   // Bowling are turned off, and fairies restore 3 hearts Otherwise, they grant a full heal, and the
   // default effect applies (full heal from bottle, 8 hearts on contact)
   u32 Settings_SetFullHealthRestore(u8 setAmount) {
-    if ((gSettingsContext.heartDropRefill ==
-         (u8)HeartDropRefillSetting::HEARTDROPREFILL_NOREFILL) ||
-        (gSettingsContext.heartDropRefill ==
-         (u8)HeartDropRefillSetting::HEARTDROPREFILL_NODROPREFILL)) {
+    if ((gSettingsContext.heartDropRefill == (u8)HeartDropRefillSetting::HEARTDROPREFILL_NOREFILL) ||
+        (gSettingsContext.heartDropRefill == (u8)HeartDropRefillSetting::HEARTDROPREFILL_NODROPREFILL)) {
       return setAmount;
     } else {
       return 0x140;

--- a/code/source/rnd/spoiler_data.cpp
+++ b/code/source/rnd/spoiler_data.cpp
@@ -15,8 +15,8 @@ namespace rnd {
   }
 
   SpoilerItemLocation GetSpoilerItemLocation(u8 sphere, u16 itemIndex) {
-    return gSpoilerData.ItemLocations
-        [gSpoilerData.SphereItemLocations[gSpoilerData.Spheres[sphere].ItemLocationsOffset]];
+    return gSpoilerData
+        .ItemLocations[gSpoilerData.SphereItemLocations[gSpoilerData.Spheres[sphere].ItemLocationsOffset]];
   }
 
   u8 SpoilerData_ChestCheck(SpoilerItemLocation itemLoc) {


### PR DESCRIPTION
Some debug fixes included in this PR to ensure that DEBUG_PRINT or ENABLE_DEBUG is required in order to print these statements.

The first clocktown fairy now gives both items, one for magic, and one for the mask.

Chests now have a counter within extdata that will give a blue rupee if the item was given. Unless it was a tradeitem.