### PR TITLE
Mystery Milk Patches

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,11 @@
+This software contains derivative work from [The Legend of Zelda: Ocarina of Time 3D Randomizer](https://github.com/gamestabled/OoT3D_Randomizer), which is licensed under MIT, and [Project Restoration](https://github.com/leoetlino/project-restoration) which is licensed under GPL, and has been given explicit permission to have his code be licensed under MIT in this project. Without any of these projects, this one would not have been possible, so thank you all.
+
+# MIT License
+
+Copyright © 2023 PhlexPlexico
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/code/include/common/advanced_context.h
+++ b/code/include/common/advanced_context.h
@@ -1,3 +1,11 @@
+/**
+ * @file advanced_context.h
+ * @author leoetlino (https://github.com/leoetlino/)
+ * @brief
+ * @date 2021-09-15
+ *
+ * Brought in from the Project Restoration libraries (context.h). Edited to adjust for the randomizer.
+ */
 #ifndef _COMMON_ADVANCED_CONTEXT_H
 #define _COMMON_ADVANCED_CONTEXT_H
 #include "z3d/z3DVec.h"

--- a/code/include/common/debug.h
+++ b/code/include/common/debug.h
@@ -1,3 +1,11 @@
+/**
+ * @file debug.h
+ * @author leoetlino (https://github.com/leoetlino/)
+ * @brief
+ * @date 2021-09-15
+ *
+ * Brought in from the Project Restoration libraries. Edited to adjust for the randomizer.
+ */
 #ifndef _COMMON_DEBUG_H
 #define _COMMON_DEBUG_H
 

--- a/code/include/common/flags.h
+++ b/code/include/common/flags.h
@@ -1,3 +1,11 @@
+/**
+ * @file flags.cpp
+ * @author leoetlino (https://github.com/leoetlino/)
+ * @brief
+ * @date 2021-09-15
+ *
+ * Brought in from the Project Restoration libraries. Edited to adjust for the randomizer.
+ */
 #ifndef _COMMON_FLAGS_H
 #define _COMMON_FLAGS_H
 

--- a/code/include/common/utils.h
+++ b/code/include/common/utils.h
@@ -1,6 +1,14 @@
 #ifndef _COMMON_UTILS_H
 #define _COMMON_UTILS_H
 
+/**
+ * @file utils.h
+ * @author leoetlino (https://github.com/leoetlino/)
+ * @brief
+ * @date 2021-09-15
+ *
+ * Brought in from the Project Restoration libraries. Edited to adjust for the randomizer.
+ */
 #include <algorithm>
 #include <cstring>
 #include <tuple>

--- a/code/include/game/actor.h
+++ b/code/include/game/actor.h
@@ -1,3 +1,11 @@
+/**
+ * @file actor.h
+ * @author leoetlino (https://github.com/leoetlino/)
+ * @brief
+ * @date 2021-09-15
+ *
+ * Brought in from the Project Restoration libraries. Edited to adjust for the randomizer.
+ */
 #ifndef _GAME_ACTOR_H
 #define _GAME_ACTOR_H
 

--- a/code/include/game/actorresource.h
+++ b/code/include/game/actorresource.h
@@ -1,3 +1,11 @@
+/**
+ * @file actorresources.h
+ * @author leoetlino (https://github.com/leoetlino/)
+ * @brief
+ * @date 2021-09-15
+ *
+ * Brought in from the Project Restoration libraries. Edited to adjust for the randomizer.
+ */
 #ifndef _GAME_ACTOR_RESOURCE_H
 #define _GAME_ACTOR_RESOURCE_H
 #define OBJECT_EXCHANGE_BANK_MAX 36

--- a/code/include/game/actors/obj_elegy_statue.h
+++ b/code/include/game/actors/obj_elegy_statue.h
@@ -1,3 +1,11 @@
+/**
+ * @file obj_elegy_statue.h
+ * @author leoetlino (https://github.com/leoetlino/)
+ * @brief
+ * @date 2021-09-15
+ *
+ * Brought in from the Project Restoration libraries. Edited to adjust for the randomizer.
+ */
 #ifndef _GAME_ACTORS_OBJ_ELEGY_STATUE
 #define _GAME_ACTORS_OBJ_ELEGY_STATUE
 

--- a/code/include/game/as.h
+++ b/code/include/game/as.h
@@ -1,3 +1,11 @@
+/**
+ * @file as.h
+ * @author leoetlino (https://github.com/leoetlino/)
+ * @brief
+ * @date 2021-09-15
+ *
+ * Brought in from the Project Restoration libraries. Edited to adjust for the randomizer.
+ */
 #ifndef _GAME_ANIMATION_SEQ_H
 #define _GAME_ANIMATION_SEQ_H
 

--- a/code/include/game/camera.h
+++ b/code/include/game/camera.h
@@ -1,3 +1,11 @@
+/**
+ * @file camera.h
+ * @author leoetlino (https://github.com/leoetlino/)
+ * @brief
+ * @date 2021-09-15
+ *
+ * Brought in from the Project Restoration libraries. Edited to adjust for the randomizer.
+ */
 #ifndef _GAME_CAMERA_H
 #define _GAME_CAMERA_H
 

--- a/code/include/game/collision.h
+++ b/code/include/game/collision.h
@@ -1,3 +1,11 @@
+/**
+ * @file collision.h
+ * @author leoetlino (https://github.com/leoetlino/)
+ * @brief
+ * @date 2021-09-15
+ *
+ * Brought in from the Project Restoration libraries. Edited to adjust for the randomizer.
+ */
 #ifndef _GAME_COLLISION_H
 #define _GAME_COLLISION_H
 

--- a/code/include/game/common_data.h
+++ b/code/include/game/common_data.h
@@ -1,3 +1,11 @@
+/**
+ * @file common_data.h
+ * @author leoetlino (https://github.com/leoetlino/)
+ * @brief
+ * @date 2021-09-15
+ *
+ * Brought in from the Project Restoration libraries. Edited to adjust for the randomizer.
+ */
 #ifndef _GAME_COMMON_DATA_H
 #define _GAME_COMMON_DATA_H
 

--- a/code/include/game/context.h
+++ b/code/include/game/context.h
@@ -1,3 +1,11 @@
+/**
+ * @file context.h
+ * @author leoetlino (https://github.com/leoetlino/)
+ * @brief
+ * @date 2021-09-15
+ *
+ * Brought in from the Project Restoration libraries. Edited to adjust for the randomizer.
+ */
 #ifndef _GAME_CONTEXT_H
 #define _GAME_CONTEXT_H
 

--- a/code/include/game/items.h
+++ b/code/include/game/items.h
@@ -1,3 +1,11 @@
+/**
+ * @file items.h
+ * @author leoetlino (https://github.com/leoetlino/)
+ * @brief
+ * @date 2021-09-15
+ *
+ * Brought in from the Project Restoration libraries. Modified for more items.
+ */
 #ifndef _GAME_ITEMS_H
 #define _GAME_ITEMS_H
 

--- a/code/include/game/message.h
+++ b/code/include/game/message.h
@@ -1,3 +1,11 @@
+/**
+ * @file message.h
+ * @author leoetlino (https://github.com/leoetlino/)
+ * @brief
+ * @date 2021-09-15
+ *
+ * Brought in from the Project Restoration libraries. Edited to adjust for the randomizer.
+ */
 #ifndef _GAME_MESSAGES_H
 #define _GAME_MESSAGES_H
 

--- a/code/include/game/pad.h
+++ b/code/include/game/pad.h
@@ -1,3 +1,11 @@
+/**
+ * @file pad.h
+ * @author leoetlino (https://github.com/leoetlino/)
+ * @brief
+ * @date 2021-09-15
+ *
+ * Brought in from the Project Restoration libraries. Edited to adjust for the randomizer.
+ */
 #ifndef _GAME_PAD_H
 #define _GAME_PAD_H
 

--- a/code/include/game/player.h
+++ b/code/include/game/player.h
@@ -8,6 +8,14 @@
 #include "game/actorresource.h"
 #include "game/as.h"
 #include "game/context.h"
+/**
+ * @file player.h
+ * @author leoetlino (https://github.com/leoetlino/)
+ * @brief
+ * @date 2021-09-15
+ *
+ * Brought in from the Project Restoration libraries. Edited to adjust for the randomizer.
+ */
 #include "game/items.h"
 #include "game/pad.h"
 #include "z3d/z3DVec.h"

--- a/code/include/game/scene.h
+++ b/code/include/game/scene.h
@@ -1,3 +1,11 @@
+/**
+ * @file scene.h
+ * @author leoetlino (https://github.com/leoetlino/)
+ * @brief
+ * @date 2021-09-15
+ *
+ * Brought in from the Project Restoration libraries. Edited to adjust for the randomizer.
+ */
 #ifndef _GAME_SCENE_H
 #define _GAME_SCENE_H
 

--- a/code/include/game/sound.h
+++ b/code/include/game/sound.h
@@ -1,3 +1,11 @@
+/**
+ * @file sound.h
+ * @author leoetlino (https://github.com/leoetlino/)
+ * @brief
+ * @date 2021-09-15
+ *
+ * Brought in from the Project Restoration libraries. Edited to adjust for the randomizer.
+ */
 #ifndef _GAME_SOUND_H
 #define _GAME_SOUND_H
 

--- a/code/include/game/states/state.h
+++ b/code/include/game/states/state.h
@@ -1,3 +1,11 @@
+/**
+ * @file state.h
+ * @author leoetlino (https://github.com/leoetlino/)
+ * @brief
+ * @date 2021-09-15
+ *
+ * Brought in from the Project Restoration libraries. Edited to adjust for the randomizer.
+ */
 #ifndef _GAME_STATES_STATE_H
 #define _GAME_STATES_STATE_H
 

--- a/code/include/game/static_context.h
+++ b/code/include/game/static_context.h
@@ -1,3 +1,11 @@
+/**
+ * @file static_context.h
+ * @author leoetlino (https://github.com/leoetlino/)
+ * @brief
+ * @date 2021-09-15
+ *
+ * Brought in from the Project Restoration libraries. Edited to adjust for the randomizer.
+ */
 #ifndef _GAME_STATIC_CONTEXT_H
 #define _GAME_STATIC_CONTEXT_H
 

--- a/code/include/game/ui.h
+++ b/code/include/game/ui.h
@@ -1,3 +1,11 @@
+/**
+ * @file ui.h
+ * @author leoetlino (https://github.com/leoetlino/)
+ * @brief
+ * @date 2021-09-15
+ *
+ * Brought in from the Project Restoration libraries. Edited to adjust for the randomizer.
+ */
 #ifndef _GAME_UI_H
 #define _GAME_UI_H
 

--- a/code/include/game/ui/layouts/message_window.h
+++ b/code/include/game/ui/layouts/message_window.h
@@ -1,3 +1,11 @@
+/**
+ * @file message_window.h
+ * @author leoetlino (https://github.com/leoetlino/)
+ * @brief
+ * @date 2021-09-15
+ *
+ * Brought in from the Project Restoration libraries. Edited to adjust for the randomizer.
+ */
 #pragma once
 
 #include "common/types.h"

--- a/code/include/game/ui/screens/screen.h
+++ b/code/include/game/ui/screens/screen.h
@@ -1,3 +1,11 @@
+/**
+ * @file screen.h
+ * @author leoetlino (https://github.com/leoetlino/)
+ * @brief
+ * @date 2021-09-15
+ *
+ * Brought in from the Project Restoration libraries. Edited to adjust for the randomizer.
+ */
 #ifndef _GAME_UI_SCREENS_SCREEN_H
 #define _GAME_UI_SCREENS_SCREEN_H
 

--- a/code/include/z3d/z3DVec.h
+++ b/code/include/z3d/z3DVec.h
@@ -1,3 +1,11 @@
+/**
+ * @file z3d.h
+ * @author gamestabled (https://github.com/gamestabled/)
+ * @brief
+ * @date 2021-09-15
+ *
+ * Brought in from the OoT3DR libraries. Edited to adjust for this randomizer.
+ */
 #ifndef _Z3DVEC_H_
 #define _Z3DVEC_H_
 

--- a/code/mm.ld
+++ b/code/mm.ld
@@ -53,18 +53,17 @@ SECTIONS{
     *(.patch_FirstZoraSwimCheck)
   }
 
-  .patch_SecondZoraSwimCheck 0x2210DC : {
-    *(.patch_SecondZoraSwimCheck)
-  }
+	.patch_DisableMilkTimer 0x234BFC : {
+		*(.patch_DisableMilkTimer)
+	}
 
-  /*0x05ffc70*/ /*0x177ddc*/ /*0x5bbab8 */ /* 0x5b8b24 */
-  .patch_LoadExtData 0x48C760 : {
-    *(.patch_LoadExtData)
-  }
-
-  .patch_SaveFile_init 0x5b8b24 : {
-    *(.patch_SaveFile_init)
-  }
+ .patch_LoadExtData 0x48C760 : {
+		*(.patch_LoadExtData)
+	}
+	 /*0x05ffc70*/ /*0x177ddc*/ /*0x5bbab8 */ /* 0x5b8b24 */
+	.patch_SaveFile_init 0x5b8b24 : {
+		*(.patch_SaveFile_init)
+	}
 
   .patch_FixSurroundSound 0x1404E8 : {
     *(.patch_FixSurroundSound)

--- a/code/mm.ld
+++ b/code/mm.ld
@@ -33,8 +33,8 @@ SECTIONS{
     *(.patch_DoNotRemoveKeys)
   }
 
-  .patch_RemoveMysteryMilkUsabilityOne 0x1DD358 : {
-    *(.patch_RemoveMysteryMilkUsabilityOne)
+  .patch_RemoveMysteryMilkUsabilityCheck 0x1e04d8 : {
+    *(.patch_RemoveMysteryMilkUsabilityCheck)
   }
 
   .patch_SpawnFastElegyStatues 0x1E9FB8 : {
@@ -92,6 +92,10 @@ SECTIONS{
 
   .patch_ISGCrouchStabOne 0x1D32E0 : {
     *(.patch_ISGCrouchStabOne)
+  }
+
+  .patch_RemoveMysteryMilkSoSCheck 0x1d79f8 : {
+    *(.patch_RemoveMysteryMilkSoSCheck)
   }
 
   .patch_ISGCrouchStabTwo 0x1DBEA4 : {

--- a/code/mm.ld
+++ b/code/mm.ld
@@ -25,6 +25,10 @@ SECTIONS{
     *(.patch_DecoupleStartSelect)
   }
 
+  .patch_RemoveMysteryMilkTimer 0x1B7A54 : {
+    *(.patch_RemoveMysteryMilkTimer)
+  }
+
   /* .patch_AttemptKeepChestsClosed 0x1c9300 : {
   *(.patch_AttemptKeepChestsClosed)
   } */

--- a/code/mm.ld
+++ b/code/mm.ld
@@ -33,8 +33,8 @@ SECTIONS{
     *(.patch_DoNotRemoveKeys)
   }
 
-  .patch_RemoveMysteryMilkUsability 0x1E04F8 : {
-    *(.patch_RemoveMysteryMilkUsability)
+  .patch_RemoveMysteryMilkUsabilityOne 0x1DD358 : {
+    *(.patch_RemoveMysteryMilkUsabilityOne)
   }
 
   .patch_SpawnFastElegyStatues 0x1E9FB8 : {

--- a/code/mm.ld
+++ b/code/mm.ld
@@ -33,6 +33,10 @@ SECTIONS{
     *(.patch_DoNotRemoveKeys)
   }
 
+  .patch_RemoveMysteryMilkUsability 0x1E04F8 : {
+    *(.patch_RemoveMysteryMilkUsability)
+  }
+
   .patch_SpawnFastElegyStatues 0x1E9FB8 : {
     *(.patch_SpawnFastElegyStatues)
   }
@@ -53,14 +57,19 @@ SECTIONS{
     *(.patch_FirstZoraSwimCheck)
   }
 
+  .patch_SecondZoraSwimCheck 0x2210DC : {
+    *(.patch_SecondZoraSwimCheck)
+  }
+
 	.patch_DisableMilkTimer 0x234BFC : {
 		*(.patch_DisableMilkTimer)
 	}
 
- .patch_LoadExtData 0x48C760 : {
-		*(.patch_LoadExtData)
-	}
-	 /*0x05ffc70*/ /*0x177ddc*/ /*0x5bbab8 */ /* 0x5b8b24 */
+  .patch_LoadExtData 0x48C760 : {
+    *(.patch_LoadExtData)
+  }
+
+  /*0x05ffc70*/ /*0x177ddc*/ /*0x5bbab8 */ /* 0x5b8b24 */
 	.patch_SaveFile_init 0x5b8b24 : {
 		*(.patch_SaveFile_init)
 	}

--- a/code/source/asm/hooks.s
+++ b/code/source/asm/hooks.s
@@ -65,7 +65,6 @@ hook_SaveFile_Init:
     pop {r0-r12, lr}
     mov r3,#0x0
     b 0x5b8b28  
-    
 
 @ State handler calls 0x5D for masks, check this value and ignore states where that is equal, since this function
 @ is also used by song of soaring and get_item.

--- a/code/source/asm/loader.c
+++ b/code/source/asm/loader.c
@@ -1,6 +1,6 @@
 /*
  * This file is a modified version of a file originally written by RicBent
- * for the program Magikoopa.
+ * for the program Magikoopa. Modified to fit alongside libctru in projects.
  */
 
 #include <3ds/svc.h>

--- a/code/source/asm/patches.s
+++ b/code/source/asm/patches.s
@@ -71,6 +71,11 @@ patch_DoNotRemoveKeys:
     nop
     nop
 
+.section .patch_DisableMilkTimer
+.global patch_DisableMilkTimer
+patch_DisableMilkTimer:
+    nop
+
 .section .patch_LoadExtData
 .global patch_LoadExtData
 patch_LoadExtData:

--- a/code/source/asm/patches.s
+++ b/code/source/asm/patches.s
@@ -71,6 +71,12 @@ patch_DoNotRemoveKeys:
     nop
     nop
 
+@ Avoids all the check items for mystery milk so we can use items freely.
+.section .patch_RemoveMysteryMilkUsability
+.global patch_RemoveMysteryMilkUsability
+patch_RemoveMysteryMilkUsability:
+    b 0x1E04EC
+
 .section .patch_DisableMilkTimer
 .global patch_DisableMilkTimer
 patch_DisableMilkTimer:

--- a/code/source/asm/patches.s
+++ b/code/source/asm/patches.s
@@ -44,6 +44,15 @@ patch_MainLoop:
 patch_DecoupleStartSelect:
     nop
 
+@ There's a while loop located in the event
+@ timer that checks if we have mystery milk.
+@ We do not wish to show this since we want to remove
+@ the timer, so we just nop the branch.
+.section .patch_RemoveMysteryMilkTimer
+.global patch_RemoveMysteryMilkTimer
+patch_RemoveMysteryMilkTimer:
+    nop
+
 @ Skip past all chest content resetting.
 @ Since this is rando, we don't want users
 @ getting chests again, and instead of

--- a/code/source/asm/patches.s
+++ b/code/source/asm/patches.s
@@ -72,9 +72,9 @@ patch_DoNotRemoveKeys:
     nop
 
 @ Avoids all the check items for mystery milk so we can use items freely.
-.section .patch_RemoveMysteryMilkUsabilityOne
-.global patch_RemoveMysteryMilkUsabilityOne
-patch_RemoveMysteryMilkUsabilityOne:
+.section .patch_RemoveMysteryMilkUsabilityCheck
+.global patch_RemoveMysteryMilkUsabilityCheck
+patch_RemoveMysteryMilkUsabilityCheck:
     nop
 
 .section .patch_DisableMilkTimer
@@ -96,6 +96,13 @@ patch_SaveFile_init:
 .global patch_GetCustomText
 patch_GetCustomText:
     b GetMessageFromId
+
+@ This removes the song of saoring check for the mystery milk.
+@ We can now soar freely.
+.section .patch_RemoveMysteryMilkSoSCheck
+.global patch_RemoveMysteryMilkSoSCheck
+patch_RemoveMysteryMilkSoSCheck:
+    mov r0, #0x0
 
 .section .patch_ISGCrouchStabOne
 .global patch_ISGCrouchStabOne

--- a/code/source/asm/patches.s
+++ b/code/source/asm/patches.s
@@ -72,10 +72,10 @@ patch_DoNotRemoveKeys:
     nop
 
 @ Avoids all the check items for mystery milk so we can use items freely.
-.section .patch_RemoveMysteryMilkUsability
-.global patch_RemoveMysteryMilkUsability
-patch_RemoveMysteryMilkUsability:
-    b 0x1E04EC
+.section .patch_RemoveMysteryMilkUsabilityOne
+.global patch_RemoveMysteryMilkUsabilityOne
+patch_RemoveMysteryMilkUsabilityOne:
+    nop
 
 .section .patch_DisableMilkTimer
 .global patch_DisableMilkTimer

--- a/code/source/asm/zora_hooks.s
+++ b/code/source/asm/zora_hooks.s
@@ -1,3 +1,5 @@
+@ This file has been taken and modified from
+@ https://github.com/leoetlino/project-restoration/blob/181ecbf6e806fc10c8d1f8b2d74489b0bd7f5e67/hooks/rst_zora_swim.hks
 .arm
 .text
 

--- a/code/source/common/common_context.cpp
+++ b/code/source/common/common_context.cpp
@@ -1,3 +1,11 @@
+/**
+ * @file common_context.cpp
+ * @author leoetlino (https://github.com/leoetlino/)
+ * @brief
+ * @date 2021-09-15
+ *
+ * Brought in from the Project Restoration libraries. Edited to adjust for the randomizer.
+ */
 #include "common/advanced_context.h"
 
 namespace rnd {

--- a/code/source/common/debug.cpp
+++ b/code/source/common/debug.cpp
@@ -1,3 +1,12 @@
+/**
+ * @file debug.cpp
+ * @author leoetlino (https://github.com/leoetlino/)
+ * @brief
+ * @date 2021-09-15
+ *
+ * Brought in from the Project Restoration libraries. Edited to adjust for the randomizer.
+ */
+
 #include "common/debug.h"
 #include "game/common_data.h"
 

--- a/code/source/game/actor.cpp
+++ b/code/source/game/actor.cpp
@@ -1,3 +1,12 @@
+/**
+ * @file actor.cpp
+ * @author leoetlino (https://github.com/leoetlino/)
+ * @brief
+ * @date 2021-09-15
+ *
+ * Brought in from the Project Restoration libraries. Edited to adjust for the randomizer.
+ */
+
 #include "game/actor.h"
 
 #include "common/utils.h"

--- a/code/source/game/actorresource.cpp
+++ b/code/source/game/actorresource.cpp
@@ -1,3 +1,12 @@
+/**
+ * @file actorresource.cpp
+ * @author leoetlino (https://github.com/leoetlino/)
+ * @brief
+ * @date 2021-09-15
+ *
+ * Brought in from the Project Restoration libraries. Edited to adjust for the randomizer.
+ */
+
 #include "game/actorresource.h"
 
 namespace game::ActorResource {

--- a/code/source/game/as.cpp
+++ b/code/source/game/as.cpp
@@ -1,3 +1,12 @@
+/**
+ * @file actor.cpp
+ * @author leoetlino (https://github.com/leoetlino/)
+ * @brief
+ * @date 2021-09-15
+ *
+ * Brought in from the Project Restoration libraries. Edited to adjust for the randomizer.
+ */
+
 #include "game/as.h"
 
 #include "common/utils.h"

--- a/code/source/game/camera.cpp
+++ b/code/source/game/camera.cpp
@@ -1,3 +1,11 @@
+/**
+ * @file camera.cpp
+ * @author leoetlino (https://github.com/leoetlino/)
+ * @brief
+ * @date 2021-09-15
+ *
+ * Brought in from the Project Restoration libraries. Edited to adjust for the randomizer.
+ */
 #include "game/camera.h"
 
 #include "common/advanced_context.h"

--- a/code/source/game/common_data.cpp
+++ b/code/source/game/common_data.cpp
@@ -1,3 +1,11 @@
+/**
+ * @file common_data.cpp
+ * @author leoetlino (https://github.com/leoetlino/)
+ * @brief
+ * @date 2021-09-15
+ *
+ * Brought in from the Project Restoration libraries. Edited to adjust for the randomizer.
+ */
 #include "game/common_data.h"
 
 #include "common/utils.h"

--- a/code/source/game/context.cpp
+++ b/code/source/game/context.cpp
@@ -1,3 +1,11 @@
+/**
+ * @file context.cpp
+ * @author leoetlino (https://github.com/leoetlino/)
+ * @brief
+ * @date 2021-09-15
+ *
+ * Brought in from the Project Restoration libraries. Edited to adjust for the randomizer.
+ */
 #include "game/context.h"
 
 #include "common/advanced_context.h"

--- a/code/source/game/items.cpp
+++ b/code/source/game/items.cpp
@@ -1,3 +1,11 @@
+/**
+ * @file items.cpp
+ * @author leoetlino (https://github.com/leoetlino/)
+ * @brief
+ * @date 2021-09-15
+ *
+ * Brought in from the Project Restoration libraries. Edited to adjust for the randomizer.
+ */
 #include "game/items.h"
 
 #include <algorithm>

--- a/code/source/game/message.cpp
+++ b/code/source/game/message.cpp
@@ -1,3 +1,11 @@
+/**
+ * @file actor.cpp
+ * @author leoetlino (https://github.com/leoetlino/)
+ * @brief
+ * @date 2021-09-15
+ *
+ * Brought in from the Project Restoration libraries. Modified for custom messages.
+ */
 #include "game/message.h"
 
 #include "common/utils.h"

--- a/code/source/game/pad.cpp
+++ b/code/source/game/pad.cpp
@@ -1,3 +1,11 @@
+/**
+ * @file pad.cpp
+ * @author leoetlino (https://github.com/leoetlino/)
+ * @brief
+ * @date 2021-09-15
+ *
+ * Brought in from the Project Restoration libraries. Edited to adjust for the randomizer.
+ */
 #include "game/pad.h"
 
 #include "common/utils.h"

--- a/code/source/game/player.cpp
+++ b/code/source/game/player.cpp
@@ -1,3 +1,11 @@
+/**
+ * @file player.cpp
+ * @author leoetlino (https://github.com/leoetlino/)
+ * @brief
+ * @date 2021-09-15
+ *
+ * Brought in from the Project Restoration libraries. Edited to adjust for the randomizer.
+ */
 #include "game/player.h"
 
 #include "common/utils.h"

--- a/code/source/game/sound.cpp
+++ b/code/source/game/sound.cpp
@@ -1,3 +1,11 @@
+/**
+ * @file sound.cpp
+ * @author leoetlino (https://github.com/leoetlino/)
+ * @brief
+ * @date 2021-09-15
+ *
+ * Brought in from the Project Restoration libraries. Edited to adjust for the randomizer.
+ */
 #include "game/sound.h"
 
 #include <tuple>

--- a/code/source/game/static_context.cpp
+++ b/code/source/game/static_context.cpp
@@ -1,3 +1,11 @@
+/**
+ * @file static_context.cpp
+ * @author leoetlino (https://github.com/leoetlino/)
+ * @brief
+ * @date 2021-09-15
+ *
+ * Brought in from the Project Restoration libraries. Edited to adjust for the randomizer.
+ */
 #include "game/static_context.h"
 
 #include "common/utils.h"

--- a/code/source/game/ui.cpp
+++ b/code/source/game/ui.cpp
@@ -1,3 +1,11 @@
+/**
+ * @file ui.cpp
+ * @author leoetlino (https://github.com/leoetlino/)
+ * @brief
+ * @date 2021-09-15
+ *
+ * Brought in from the Project Restoration libraries. Edited to adjust for the randomizer.
+ */
 #include "game/ui.h"
 
 #include <string_view>

--- a/code/source/rnd/item_override.cpp
+++ b/code/source/rnd/item_override.cpp
@@ -39,9 +39,9 @@ namespace rnd {
     rItemOverrides[0].value.getItemId = 0x26;
     rItemOverrides[0].value.looksLikeItemId = 0x26;
     rItemOverrides[1].key.scene = 0x6C;
-    rItemOverrides[1].key.type = ItemOverride_Type::OVR_COLLECTABLE;
-    rItemOverrides[1].value.getItemId = 0x9A;
-    rItemOverrides[1].value.looksLikeItemId = 0x2C;
+    rItemOverrides[1].key.type = ItemOverride_Type::OVR_CHEST;
+    rItemOverrides[1].value.getItemId = 0x70;
+    rItemOverrides[1].value.looksLikeItemId = 0x70;
     rItemOverrides[2].key.scene = 0x12;
     rItemOverrides[2].key.type = ItemOverride_Type::OVR_COLLECTABLE;
     rItemOverrides[2].value.getItemId = 0x37;

--- a/code/source/rnd/savefile.cpp
+++ b/code/source/rnd/savefile.cpp
@@ -730,7 +730,7 @@ namespace rnd {
 
   void SaveFile_InitExtSaveData(u32 saveNumber) {
 #if defined ENABLE_DEBUG || defined DEBUG_PRINT
-    rnd::util::Print("%s: INITING ExtData.\n", __func__);
+    util::Print("%s: INITING ExtData.\n", __func__);
 #endif
     gExtSaveData.version = EXTSAVEDATA_VERSION;  // Do not change this line
     gExtSaveData.isNewFile = 1;
@@ -789,9 +789,10 @@ namespace rnd {
     extDataReadFile(fileHandle, &version, 0, sizeof(version));
     extDataReadFile(fileHandle, &newSave, 8, sizeof(newSave));
 #if defined ENABLE_DEBUG || defined DEBUG_PRINT
-    rnd::util::Print("%s: Is New file? %u\n", __func__, newSave);
+    util::Print("%s: Is New file? %u\n", __func__, newSave);
 #endif
-    if (fileSize != sizeof(gExtSaveData) || version != EXTSAVEDATA_VERSION || gExtSaveData.isNewFile == 1) {
+    if (fileSize != sizeof(gExtSaveData) || version != EXTSAVEDATA_VERSION ||
+        gExtSaveData.isNewFile == 1) {
       extDataClose(fileHandle);
       extDataDeleteFile(fsa, path);
       SaveFile_InitExtSaveData(saveNumber);

--- a/code/source/rnd/savefile.cpp
+++ b/code/source/rnd/savefile.cpp
@@ -791,8 +791,7 @@ namespace rnd {
 #if defined ENABLE_DEBUG || defined DEBUG_PRINT
     util::Print("%s: Is New file? %u\n", __func__, newSave);
 #endif
-    if (fileSize != sizeof(gExtSaveData) || version != EXTSAVEDATA_VERSION ||
-        gExtSaveData.isNewFile == 1) {
+    if (fileSize != sizeof(gExtSaveData) || version != EXTSAVEDATA_VERSION || gExtSaveData.isNewFile == 1) {
       extDataClose(fileHandle);
       extDataDeleteFile(fsa, path);
       SaveFile_InitExtSaveData(saveNumber);


### PR DESCRIPTION
This feature now brings removing restrictions for mystery milk. In the original game upon receiving the item, you are given a timer on screen for which you must deliver the milk by or else it will spoil. These patches remove the timer, and remove any item restrictions associated with having the milk in your inventory, such as not being able to use song of soaring, or using goron mask.

Huge shoutouts to @leoetlino for helping me find the event timer!

This merge also includes proper licensing in the patch side itself. 