### PR TITLE
Mikau and Gibdo Give Items

### DIFF
--- a/code/include/game/actor.h
+++ b/code/include/game/actor.h
@@ -54,15 +54,19 @@ namespace game::act {
     // [7] Owl statue
     ObjOwlStatue = 0x01B2,
     // [4] Old Lady from Bomb Shop
-    NpcOldLady = 0x01C5,
+    NpcEnBaba = 0x01C5,
     // Granny
     NpcEnNb = 0x01D2,
+    // GuruGuru (Bremen Mask Give Item)
+    NpcEnGuruGuru = 0x01D7,
     // Npc Invisible Guard
     NpcInvisibleGuard = 0x1D9,
     // Npc Madame Aroma
     NpcAroma = 0x1F1,
     // [4] Rosa Sisters
     NpcRosaSisters = 0x020A,
+    // En_Yb (Kamarao)
+    NpcEnYb = 0x0209,
     // En_Bjt (Toilet Hand)
     NpcEnBjt = 0x020C,
     // [4] Bombers

--- a/code/include/game/common_data.h
+++ b/code/include/game/common_data.h
@@ -397,7 +397,7 @@ namespace game {
       BitField<6, 1, u8> has_worn_zora_mask_once;
       BitField<7, 1, u8> has_worn_deity_mask_once;
     };
-    HaveWornMasks set_fast_mask_animations;
+    HaveWornMasks have_worn_mask_once;
     union AdditonalTatlDialogueFlags {
       u8 raw;
 

--- a/code/include/rnd/item_table.h
+++ b/code/include/rnd/item_table.h
@@ -36,6 +36,7 @@ namespace rnd {
 
   extern "C" ItemRow rItemTable[];
   extern "C" ItemRow* rActiveItemRow;
+  extern "C" u32 rActiveItemTextId;
   u16 ItemTable_ResolveUpgrades(u16 itemId);
   ItemRow* ItemTable_GetItemRow(u16 itemId);
   ItemRow* ItemTable_GetItemRowFromIndex(u8 rowIndex);

--- a/code/include/rnd/savefile.h
+++ b/code/include/rnd/savefile.h
@@ -35,12 +35,22 @@ namespace rnd {
     u32 isNewFile;
     u8 playedSosOnce;
     u8 playedElegyOnce;
-    s8 aromaGivenItem;
-    s8 grannyGaveReward;
-    s8 stoneMaskReward;
-    s8 mummyDaddyReward;
-    s8 mikauReward;
-    s8 darmaniReward;
+    union GivenItemRegister {
+      u16 raw;
+
+      BitField<0, 1, u16> enNbGivenItem;
+      BitField<1, 1, u16> enAlGivenItem;
+      BitField<2, 1, u16> enBabaGivenItem;
+      BitField<3, 1, u16> enStoneHeishiGivenItem;
+      BitField<4, 1, u16> mummyDaddyGivenItem;
+      BitField<5, 1, u16> enGuruGuruGivenItem;
+      BitField<6, 1, u16> enYbGivenItem;
+      BitField<7, 1, u16> enGegGivenItem;
+      BitField<8, 1, u16> enZogGivenItem;
+      BitField<9, 1, u16> enGgGivenItem;
+      BitField<10, 6, u16> unused;
+    };
+    GivenItemRegister givenItemChecks; 
     union FairyCollectRegister {
       u8 raw;
 

--- a/code/include/rnd/savefile.h
+++ b/code/include/rnd/savefile.h
@@ -7,7 +7,7 @@
 #include "z3d/z3DVec.h"
 
 // Increment the version number whenever the ExtSaveData structure is changed
-#define EXTSAVEDATA_VERSION 02
+#define EXTSAVEDATA_VERSION 03
 
 namespace rnd {
   void SaveFile_SkipMinorCutscenes();
@@ -25,12 +25,9 @@ namespace rnd {
   void SaveFile_SetOwnedTradeItemEquipped(void);
   void SaveFile_ResetItemSlotsIfMatchesID(u8 itemSlot);
   bool SaveFile_IsValidSettingsHealth(void);
-  // extern "C" {
   void SaveFile_InitExtSaveData(u32 fileBaseIndex);
   void SaveFile_LoadExtSaveData(u32 saveNumber);
   extern "C" void SaveFile_SaveExtSaveData();
-
-  //}
 
   typedef struct {
     u32 version;  // Needs to always be the first field of the structure
@@ -41,6 +38,9 @@ namespace rnd {
     s8 aromaGivenItem;
     s8 grannyGaveReward;
     s8 stoneMaskReward;
+    s8 mummyDaddyReward;
+    s8 mikauReward;
+    s8 darmaniReward;
     union FairyCollectRegister {
       u8 raw;
 

--- a/code/include/rnd/savefile.h
+++ b/code/include/rnd/savefile.h
@@ -50,7 +50,7 @@ namespace rnd {
       BitField<9, 1, u16> enGgGivenItem;
       BitField<10, 6, u16> unused;
     };
-    GivenItemRegister givenItemChecks; 
+    GivenItemRegister givenItemChecks;
     union FairyCollectRegister {
       u8 raw;
 

--- a/code/include/rnd/settings.h
+++ b/code/include/rnd/settings.h
@@ -199,7 +199,7 @@ namespace rnd {
     STARTINGWALLET_GIANT,
     STARTINGWALLET_TYCOON,
   };
-  
+
   enum class StartingSwordSetting : u8 {
     STARTINGSWORD_NONE,
     STARTINGSWORD_KOKIRI,

--- a/code/include/rnd/settings.h
+++ b/code/include/rnd/settings.h
@@ -193,6 +193,13 @@ namespace rnd {
     STARTINGBOTTLE_MYSTERY_MILK_SPOILED,
   };
 
+  enum class StartingWalletSetting : u8 {
+    STARTINGWALLET_NONE,
+    STARTINGWALLET_ADULT,
+    STARTINGWALLET_GIANT,
+    STARTINGWALLET_TYCOON,
+  };
+  
   enum class StartingSwordSetting : u8 {
     STARTINGSWORD_NONE,
     STARTINGSWORD_KOKIRI,

--- a/code/mm.ld
+++ b/code/mm.ld
@@ -45,6 +45,10 @@ SECTIONS{
     *(.patch_SpawnFastElegyStatues)
   }
 
+  .patch_CheckCurrentInventoryOverrideItem 0x1F3D60 : {
+    *(.patch_CheckCurrentInventoryOverrideItem)
+  }
+
   .patch_UseZoraASwimSecond 0X1FFD74 : {
     *(.patch_UseZoraASwimSecond)
   }

--- a/code/mm.ld
+++ b/code/mm.ld
@@ -150,8 +150,16 @@ SECTIONS{
     *(.patch_SaveExtDataOnOwl)
   }
 
+  .patch_RemoveZoraMaskCheckMikau 0x32bbb8 : {
+    *(.patch_RemoveZoraMaskCheckMikau)
+  }
+
   .patch_AromaItemCheck 0x35091C : {
     *(.patch_AromaItemCheck)
+  }
+
+  .patch_ZoraMaskGiveItem 0x41DB84 : {
+    *(.patch_ZoraMaskGiveItem)
   }
 
   .patch_IncomingGetItemID 0x4B1394 : {

--- a/code/mm.ld
+++ b/code/mm.ld
@@ -172,6 +172,11 @@ SECTIONS{
   .patch_RemoveZoraMaskAppearing 0x41DB98 : {
     *(.patch_RemoveZoraMaskAppearing)
   }
+
+  .patch_GibdoMaskGiveItem 0x41DC48 : {
+    *(.patch_GibdoMaskGiveItem)
+  }
+
   .patch_IncomingGetItemID 0x4B1394 : {
     *(.patch_IncomingGetItemID)
   }

--- a/code/mm.ld
+++ b/code/mm.ld
@@ -169,7 +169,9 @@ SECTIONS{
   .patch_ZoraMaskGiveItem 0x41DB80 : {
     *(.patch_ZoraMaskGiveItem)
   }
-
+  .patch_RemoveZoraMaskAppearing 0x41DB98 : {
+    *(.patch_RemoveZoraMaskAppearing)
+  }
   .patch_IncomingGetItemID 0x4B1394 : {
     *(.patch_IncomingGetItemID)
   }

--- a/code/mm.ld
+++ b/code/mm.ld
@@ -158,9 +158,9 @@ SECTIONS{
     *(.patch_AromaItemCheck)
   }
 
-  .patch_ZoraMaskGiveItem 0x41DB84 : {
+  /* .patch_ZoraMaskGiveItem 0x41DB80 : {
     *(.patch_ZoraMaskGiveItem)
-  }
+  } */
 
   .patch_IncomingGetItemID 0x4B1394 : {
     *(.patch_IncomingGetItemID)

--- a/code/mm.ld
+++ b/code/mm.ld
@@ -25,6 +25,10 @@ SECTIONS{
     *(.patch_DecoupleStartSelect)
   }
 
+  .patch_RemoveMessageZoraMaskMaybeMore 0x186810 : {
+    *(.patch_RemoveMessageZoraMaskMaybeMore)
+  }
+
   .patch_RemoveMysteryMilkTimer 0x1B7A54 : {
     *(.patch_RemoveMysteryMilkTimer)
   }
@@ -162,9 +166,9 @@ SECTIONS{
     *(.patch_AromaItemCheck)
   }
 
-  /* .patch_ZoraMaskGiveItem 0x41DB80 : {
+  .patch_ZoraMaskGiveItem 0x41DB80 : {
     *(.patch_ZoraMaskGiveItem)
-  } */
+  }
 
   .patch_IncomingGetItemID 0x4B1394 : {
     *(.patch_IncomingGetItemID)

--- a/code/mm.ld
+++ b/code/mm.ld
@@ -45,7 +45,7 @@ SECTIONS{
     *(.patch_SpawnFastElegyStatues)
   }
 
-  .patch_CheckCurrentInventoryOverrideItem 0x1F3D60 : {
+  .patch_CheckCurrentInventoryOverrideItem 0x1F3D6C : {
     *(.patch_CheckCurrentInventoryOverrideItem)
   }
 

--- a/code/patch.py
+++ b/code/patch.py
@@ -35,7 +35,7 @@ with open(elf, 'rb') as e:
         e.seek(offset, 0)
         while size > 65535:
             patch = e.read(65535)
-            print('{:0X}'.format(vaddr), '{:0X}'.format(vaddr + size), name)
+            #print('{:0X}'.format(vaddr), '{:0X}'.format(vaddr + size), name)
             ips += off(vaddr)
             ips += sz(65535)
             ips += patch

--- a/code/source/asm/hooks.s
+++ b/code/source/asm/hooks.s
@@ -26,6 +26,18 @@ hook_SpawnFastElegyStatues:
     beq 0x1E9FBC
     bx lr
 
+.global hook_CheckCurrentInventory
+hook_CheckCurrentInventory:
+    push {r1, lr}
+    bl ItemOverride_CheckInventoryItemOverride
+    cmp r0,#0xFF
+    beq DoNotOverrideInventoryCheck
+    pop {r1, lr}
+    bx lr
+DoNotOverrideInventoryCheck:
+    ldrb r0,[r1,r0]
+    b 0x1F3D64
+
 .global hook_CheckOcarinaDive
 hook_CheckOcarinaDive:
     push {r0-r12, lr}

--- a/code/source/asm/hooks.s
+++ b/code/source/asm/hooks.s
@@ -186,6 +186,18 @@ hook_OwlExtDataSave:
     cpy r6,r0
     b 0x317008
 
+.global hook_MikauRewardCheck
+hook_MikauRewardCheck:
+    push {r0-r12, lr}
+    bl ItemOverride_CheckMikauGivenItem
+    cmp r0,#0x1
+    pop {r0-r12, lr}
+    beq doNotSpawnMikau
+    b 0x32BC20
+doNotSpawnMikau:
+    nop
+    b 0x32BBDC
+
 .global hook_AromaItemCheck
 hook_AromaItemCheck:
     push {r0-r12, lr}

--- a/code/source/asm/hooks.s
+++ b/code/source/asm/hooks.s
@@ -1,6 +1,10 @@
 .arm
 .text
 
+.global rActiveItemTextId
+.rActiveItemTextId_addr:
+    .word rActiveItemTextId
+
 .global hook_Start
 hook_Start:
     push {r0-r12, lr}
@@ -15,6 +19,23 @@ hook_MainLoop:
     pop {r0-r12, lr}
     ldr r1, [r0,#0x138]
     b 0x0106770
+
+.global hook_CheckShowMessageTimeStuff
+hook_CheckShowMessageTimeStuff:
+    push {r1}
+    ldr r1,.rActiveItemTextId_addr
+    ldr r1,[r1]
+    cmp r1,#0x0
+    pop {r1}
+    beq 0x186810
+    ldr r1,.rActiveItemTextId_addr
+    ldr r1,[r1]
+    b 0x186810
+    @ push {r0-r12}
+    @ bl ItemOverride_OverrideTextIDMajorItems
+    @ pop {r0,r12}
+    @ b 0x186814
+    @ b 0x21BAFC
 
 .global hook_SpawnFastElegyStatues
 hook_SpawnFastElegyStatues:

--- a/code/source/asm/hooks.s
+++ b/code/source/asm/hooks.s
@@ -246,6 +246,30 @@ noOverrideMikauItemID:
     bl 0x233BEC
     b 0x41DB84
 
+.global hook_GibdoMaskGiveItem
+hook_GibdoMaskGiveItem:
+    push {r0-r12, lr}
+    cpy r0,r5
+    cpy r1,r4
+    mov r2,#0x7A
+    bl ItemOverride_GetSoHItem
+    ldr r5,.rActiveItemRow_addr
+    ldr r5,[r5]
+    cmp r5,#0x0
+    pop {r0-r12, lr}
+    beq noOverrideGibdoItemID
+    push {r0-r12, lr}
+    cpy r0,r5
+    cpy r1,r4
+    bl ItemOverride_GetItemTextAndItemID
+    pop {r0-r12, lr}
+    cpy r0,r5
+    b 0x41DC4C
+noOverrideGibdoItemID:
+    cpy r0,r5
+    bl 0x233BEC
+    b 0x41DC4C
+
 .section .loader
 .global hook_into_loader
 hook_into_loader:

--- a/code/source/asm/hooks.s
+++ b/code/source/asm/hooks.s
@@ -206,6 +206,30 @@ hook_AromaItemCheck:
     pop {r0-r12, lr}
     b 0x350920
 
+.global hook_ZoraMaskGiveItem
+hook_ZoraMaskGiveItem:
+    push {r0-r12, lr}
+    cpy r0,r5
+    cpy r1,r4
+    mov r2,#0x7A
+    bl ItemOverride_GetSoHItem
+    ldr r5,.rActiveItemRow_addr
+    ldr r5,[r5]
+    cmp r5,#0x0
+    pop {r0-r12, lr}
+    beq noOverrideMikauItemID
+    push {r0-r12, lr}
+    cpy r0,r5
+    cpy r1,r4
+    bl ItemOverride_GetItemTextAndItemID
+    pop {r0-r12, lr}
+    cpy r0,r5
+    b 0x41DB84
+noOverrideMikauItemID:
+    cpy r0,r5
+    bl 0x233BEC
+    b 0x41DB84
+
 .section .loader
 .global hook_into_loader
 hook_into_loader:

--- a/code/source/asm/hooks.s
+++ b/code/source/asm/hooks.s
@@ -31,12 +31,11 @@ hook_CheckCurrentInventory:
     push {r1, lr}
     bl ItemOverride_CheckInventoryItemOverride
     cmp r0,#0xFF
-    beq DoNotOverrideInventoryCheck
     pop {r1, lr}
+    bne DoNotOverrideInventoryCheck
     bx lr
 DoNotOverrideInventoryCheck:
-    ldrb r0,[r1,r0]
-    b 0x1F3D64
+    bx lr
 
 .global hook_CheckOcarinaDive
 hook_CheckOcarinaDive:

--- a/code/source/asm/hooks.s
+++ b/code/source/asm/hooks.s
@@ -22,15 +22,19 @@ hook_MainLoop:
 
 .global hook_CheckShowMessageTimeStuff
 hook_CheckShowMessageTimeStuff:
-    push {r1}
+    push {r0-r12,lr}
     ldr r1,.rActiveItemTextId_addr
     ldr r1,[r1]
     cmp r1,#0x0
-    pop {r1}
-    beq 0x186810
+    pop {r0-r12,lr}
+    beq DoNotOverrideMajorItemText
     ldr r1,.rActiveItemTextId_addr
     ldr r1,[r1]
-    b 0x186810
+    b 0x21BAFC
+    bx lr
+DoNotOverrideMajorItemText:
+    b 0x21BAFC
+    bx lr
     @ push {r0-r12}
     @ bl ItemOverride_OverrideTextIDMajorItems
     @ pop {r0,r12}

--- a/code/source/asm/hooks.s
+++ b/code/source/asm/hooks.s
@@ -20,26 +20,6 @@ hook_MainLoop:
     ldr r1, [r0,#0x138]
     b 0x0106770
 
-.global hook_CheckShowMessageTimeStuff
-hook_CheckShowMessageTimeStuff:
-    push {r0-r12,lr}
-    ldr r1,.rActiveItemTextId_addr
-    ldr r1,[r1]
-    cmp r1,#0x0
-    pop {r0-r12,lr}
-    beq DoNotOverrideMajorItemText
-    ldr r1,.rActiveItemTextId_addr
-    ldr r1,[r1]
-    b 0x21BAFC
-    bx lr
-DoNotOverrideMajorItemText:
-    b 0x21BAFC
-    bx lr
-    @ push {r0-r12}
-    @ bl ItemOverride_OverrideTextIDMajorItems
-    @ pop {r0,r12}
-    @ b 0x186814
-    @ b 0x21BAFC
 
 .global hook_SpawnFastElegyStatues
 hook_SpawnFastElegyStatues:

--- a/code/source/asm/patches.s
+++ b/code/source/asm/patches.s
@@ -55,7 +55,7 @@ patch_DecoupleStartSelect:
 .section .patch_RemoveMessageZoraMaskMaybeMore
 .global patch_RemoveMessageZoraMaskMaybeMore
 patch_RemoveMessageZoraMaskMaybeMore:
-    b hook_CheckShowMessageTimeStuff
+    nop
 
 @ There's a while loop located in the event
 @ timer that checks if we have mystery milk.

--- a/code/source/asm/patches.s
+++ b/code/source/asm/patches.s
@@ -246,6 +246,11 @@ patch_ZoraMaskGiveItem:
 .global patch_RemoveZoraMaskAppearing
 patch_RemoveZoraMaskAppearing:
     nop
+    
+.section .patch_GibdoMaskGiveItem
+.global patch_GibdoMaskGiveItem
+patch_GibdoMaskGiveItem:
+    b hook_GibdoMaskGiveItem
 
 .section .patch_loader
 .global loader_patch

--- a/code/source/asm/patches.s
+++ b/code/source/asm/patches.s
@@ -224,6 +224,11 @@ patch_RemoveZoraMaskCheckMikau:
 patch_AromaItemCheck:
     b hook_AromaItemCheck
 
+.section .patch_ZoraMaskGiveItem
+.global patch_ZoraMaskGiveItem
+patch_ZoraMaskGiveItem:
+    b hook_ZoraMaskGiveItem
+
 .section .patch_loader
 .global loader_patch
 loader_patch:

--- a/code/source/asm/patches.s
+++ b/code/source/asm/patches.s
@@ -242,6 +242,11 @@ patch_AromaItemCheck:
 patch_ZoraMaskGiveItem:
     b hook_ZoraMaskGiveItem
 
+.section .patch_RemoveZoraMaskAppearing
+.global patch_RemoveZoraMaskAppearing
+patch_RemoveZoraMaskAppearing:
+    nop
+
 .section .patch_loader
 .global loader_patch
 loader_patch:

--- a/code/source/asm/patches.s
+++ b/code/source/asm/patches.s
@@ -10,6 +10,11 @@ patch_DecoupleZlZr:
 patch_SpawnFastElegyStatues: 
     b hook_SpawnFastElegyStatues
 
+.section .patch_CheckCurrentInventoryOverrideItem
+.global patch_CheckCurrentInventoryOverrideItem
+patch_CheckCurrentInventoryOverrideItem:
+    b hook_CheckCurrentInventory
+
 .section .patch_startHeap
 .global patch_startHeap
 patch_startHeap:

--- a/code/source/asm/patches.s
+++ b/code/source/asm/patches.s
@@ -49,6 +49,14 @@ patch_MainLoop:
 patch_DecoupleStartSelect:
     nop
 
+@ This should remove the overwriting message for when the
+@ user receives the Zora Mask.
+@ Largely untested, need to check for any UB.
+.section .patch_RemoveMessageZoraMaskMaybeMore
+.global patch_RemoveMessageZoraMaskMaybeMore
+patch_RemoveMessageZoraMaskMaybeMore:
+    b hook_CheckShowMessageTimeStuff
+
 @ There's a while loop located in the event
 @ timer that checks if we have mystery milk.
 @ We do not wish to show this since we want to remove

--- a/code/source/asm/patches.s
+++ b/code/source/asm/patches.s
@@ -214,6 +214,11 @@ patch_FasterBlockMovementBack:
 patch_SaveExtDataOnOwl:
     b hook_OwlExtDataSave
 
+.section .patch_RemoveZoraMaskCheckMikau
+.global patch_RemoveZoraMaskCheckMikau
+patch_RemoveZoraMaskCheckMikau:
+    b hook_MikauRewardCheck
+
 .section .patch_AromaItemCheck
 .global patch_AromaItemCheck
 patch_AromaItemCheck:

--- a/code/source/rnd/item_effect.cpp
+++ b/code/source/rnd/item_effect.cpp
@@ -126,6 +126,7 @@ namespace rnd {
   void ItemEffect_GiveDoubleDefense(game::CommonData* comData, s16 arg1, s16 arg2) {
     comData->save.player.double_defense = 1;
     comData->save.player.anonymous_19 = 1;
+    comData->save.inventory.items[0] = game::ItemId::Ocarina;
     if ((gSettingsContext.heartDropRefill != (u8)HeartDropRefillSetting::HEARTDROPREFILL_NOREFILL) &&
         (gSettingsContext.heartDropRefill != (u8)HeartDropRefillSetting::HEARTDROPREFILL_NODROPREFILL)) {
       comData->save.player.health_current = comData->save.player.health_max;

--- a/code/source/rnd/item_override.cpp
+++ b/code/source/rnd/item_override.cpp
@@ -383,21 +383,27 @@ namespace rnd {
     s16 getItemId = incomingNegative ? -originalGetItemId : originalGetItemId;
     // TODO: Granny Override here - check actor scene, and check gExtData.
     if (actorId == game::act::Id::NpcEnNb) {
-      if (gExtSaveData.grannyGaveReward > 0) {
+      if (gExtSaveData.givenItemChecks.enNbGivenItem > 0) {
         getItemId = incomingNegative ? -0xBA : 0xBA;
       }
-      gExtSaveData.grannyGaveReward++;
+      gExtSaveData.givenItemChecks.enNbGivenItem = 1;
     } else if (actorId == game::act::Id::NpcEnBjt) {
       getItemId = incomingNegative ? -0x01 : 0x01;
     } else if (actorId == game::act::Id::NpcSwampPhotographer) {
       getItemId = incomingNegative ? -0xBA : 0xBA;
     } else if (actorId == game::act::Id::NpcInvisibleGuard) {
-      if (gExtSaveData.stoneMaskReward > 0) {
+      if (gExtSaveData.givenItemChecks.enStoneHeishiGivenItem > 0) {
         getItemId = incomingNegative ? -0xBA : 0xBA;
       }
-      gExtSaveData.stoneMaskReward++;
+      gExtSaveData.givenItemChecks.enStoneHeishiGivenItem = 1;
     } else if (actorId == game::act::Id::NpcAroma) {
-      gExtSaveData.aromaGivenItem++;
+      gExtSaveData.givenItemChecks.enAlGivenItem = 1;
+    } else if (actorId == game::act::Id::NpcEnGuruGuru) {
+      gExtSaveData.givenItemChecks.enGuruGuruGivenItem = 1;
+    } else if (actorId == game::act::Id::NpcEnYb) {
+      gExtSaveData.givenItemChecks.enYbGivenItem = 1;
+    } else if (actorId == game::act::Id::NpcEnBaba) {
+      gExtSaveData.givenItemChecks.enBabaGivenItem = 1;
     }
     return getItemId;
   }
@@ -426,13 +432,13 @@ namespace rnd {
 
   extern "C" {
   bool ItemOverride_CheckAromaGivenItem() {
-    if (gExtSaveData.aromaGivenItem > 0)
+    if (gExtSaveData.givenItemChecks.enAlGivenItem > 0)
       return true;
     return false;
   }
 
   bool ItemOverride_CheckMikauGivenItem() {
-    if (gExtSaveData.mikauReward > 0)
+    if (gExtSaveData.givenItemChecks.enZogGivenItem > 0)
       return true;
     return false;
   }
@@ -540,11 +546,11 @@ namespace rnd {
     rnd::util::Print("%s: Song of healing item is now being obtained. Item ID is %i\n", __func__, incomingItemId);
 #endif
     if (incomingItemId == 0x7A) {
-      gExtSaveData.mikauReward = 1;
+      gExtSaveData.givenItemChecks.enZogGivenItem = 1;
     } else if (incomingItemId == 0x79) {
-      gExtSaveData.darmaniReward = 1;
+      gExtSaveData.givenItemChecks.enGgGivenItem = 1;
     } else if (incomingItemId == 0x87) {
-      gExtSaveData.mummyDaddyReward = 1;
+      gExtSaveData.givenItemChecks.mummyDaddyGivenItem = 1;
     }
     ItemOverride_GetItem(gctx, fromActor, gctx->GetPlayerActor(), incomingItemId);
     return;
@@ -555,19 +561,14 @@ namespace rnd {
   }
 
   int ItemOverride_CheckInventoryItemOverride(game::ItemId currentItem) {
-    if (currentItem == game::ItemId::BlastMask) {
-      if (gExtSaveData.grannyGaveReward == 0) {
-#if defined ENABLE_DEBUG || defined DEBUG_PRINT
-        rnd::util::Print("%s: Checking inventory current item is %04x and granny reward is %u\n", __func__, currentItem,
-                         gExtSaveData.grannyGaveReward);
-#endif
+    if (currentItem == game::ItemId::BlastMask && gExtSaveData.givenItemChecks.enBabaGivenItem == 0) {
+      return (int)0xFF;
+    } else if (currentItem == game::ItemId::BremenMask && gExtSaveData.givenItemChecks.enGuruGuruGivenItem == 0) {
+      return (int)0xFF;
+    }  else if (currentItem == game::ItemId::KamaroMask && gExtSaveData.givenItemChecks.enYbGivenItem == 0) {
         return (int)0xFF;
-      }
-
-      else
-        return (int)currentItem;
-    } else if (currentItem == game::ItemId::DonGeroMask) {
-      return (int)currentItem;
+    } else if (currentItem == game::ItemId::DonGeroMask && gExtSaveData.givenItemChecks.enGegGivenItem == 0) {
+        return (int)0xFF;
     }
 
     return (int)currentItem;

--- a/code/source/rnd/item_override.cpp
+++ b/code/source/rnd/item_override.cpp
@@ -452,7 +452,8 @@ namespace rnd {
 #endif
         if (rActiveItemRow->itemId < 0x28 && rActiveItemRow->itemId > 0x30) {
 #if defined ENABLE_DEBUG || defined DEBUG_PRINT
-          rnd::util::Print("%s:\n", __func__);
+          rnd::util::Print("%s: Setting indicies rActiveItemOverride.key.scene  %u and rActiveItemOverride.key.flag %u to retrieved.\n", \
+          __func__, rActiveItemOverride.key.scene, rActiveItemOverride.key.flag);
 #endif
           gExtSaveData.chestRewarded[rActiveItemOverride.key.scene][rActiveItemOverride.key.flag] = 1;
         }
@@ -462,6 +463,9 @@ namespace rnd {
       u16 textId = rActiveItemRow->textId;
       u8 itemId = rActiveItemRow->itemId;
       ItemTable_CallEffect(rActiveItemRow);
+      #if defined ENABLE_DEBUG || defined DEBUG_PRINT
+          rnd::util::Print("%s:Player Item ID is %#04x\n", __func__, actor->get_item_id);
+      #endif
       gctx->ShowMessage(textId, actor);
       // Get_Item_Handler. Don't give ice traps, since it may cause UB.
       if (itemId != (u8)game::ItemId::X82 && itemId != (u8)game::ItemId::None) {

--- a/code/source/rnd/item_override.cpp
+++ b/code/source/rnd/item_override.cpp
@@ -553,5 +553,18 @@ namespace rnd {
   void ItemOverride_RemoveTextId() {
     rStoredBomberNoteTextId = 0;
   }
+
+  int ItemOverride_CheckInventoryItemOverride(game::ItemId currentItem) {
+    if (currentItem == game::ItemId::BlastMask) {
+      if (gExtSaveData.grannyGaveReward == 0)
+        return 0xFF;
+      else
+        return (int)currentItem;
+    } else if (currentItem == game::ItemId::DonGeroMask) {
+      return (int)currentItem;
+    }
+
+    return 0xFF;
+  }
   }
 }  // namespace rnd

--- a/code/source/rnd/item_override.cpp
+++ b/code/source/rnd/item_override.cpp
@@ -430,6 +430,13 @@ namespace rnd {
       return true;
     return false;
   }
+
+  bool ItemOverride_CheckMikauGivenItem() {
+    if (gExtSaveData.mikauReward > 0)
+      return true;
+    return false;
+  }
+
   void ItemOverride_GetItemTextAndItemID(game::act::Player* actor) {
     if (rActiveItemRow != NULL) {
       if (rActiveItemOverride.key.type == ItemOverride_Type::OVR_CHEST) {

--- a/code/source/rnd/item_override.cpp
+++ b/code/source/rnd/item_override.cpp
@@ -40,8 +40,8 @@ namespace rnd {
     rItemOverrides[0].value.looksLikeItemId = 0x26;
     rItemOverrides[1].key.scene = 0x6C;
     rItemOverrides[1].key.type = ItemOverride_Type::OVR_COLLECTABLE;
-    rItemOverrides[1].value.getItemId = 0xB2;
-    rItemOverrides[1].value.looksLikeItemId = 0xB2;
+    rItemOverrides[1].value.getItemId = 0x12;
+    rItemOverrides[1].value.looksLikeItemId = 0x12;
     rItemOverrides[2].key.scene = 0x12;
     rItemOverrides[2].key.type = ItemOverride_Type::OVR_COLLECTABLE;
     rItemOverrides[2].value.getItemId = 0x37;
@@ -452,8 +452,9 @@ namespace rnd {
 #endif
         if (rActiveItemRow->itemId < 0x28 && rActiveItemRow->itemId > 0x30) {
 #if defined ENABLE_DEBUG || defined DEBUG_PRINT
-          rnd::util::Print("%s: Setting indicies rActiveItemOverride.key.scene  %u and rActiveItemOverride.key.flag %u to retrieved.\n", \
-          __func__, rActiveItemOverride.key.scene, rActiveItemOverride.key.flag);
+          rnd::util::Print("%s: Setting indicies rActiveItemOverride.key.scene  %u and rActiveItemOverride.key.flag %u "
+                           "to retrieved.\n",
+                           __func__, rActiveItemOverride.key.scene, rActiveItemOverride.key.flag);
 #endif
           gExtSaveData.chestRewarded[rActiveItemOverride.key.scene][rActiveItemOverride.key.flag] = 1;
         }
@@ -463,9 +464,9 @@ namespace rnd {
       u16 textId = rActiveItemRow->textId;
       u8 itemId = rActiveItemRow->itemId;
       ItemTable_CallEffect(rActiveItemRow);
-      #if defined ENABLE_DEBUG || defined DEBUG_PRINT
-          rnd::util::Print("%s:Player Item ID is %#04x\n", __func__, actor->get_item_id);
-      #endif
+#if defined ENABLE_DEBUG || defined DEBUG_PRINT
+      rnd::util::Print("%s:Player Item ID is %#04x\n", __func__, actor->get_item_id);
+#endif
       gctx->ShowMessage(textId, actor);
       // Get_Item_Handler. Don't give ice traps, since it may cause UB.
       if (itemId != (u8)game::ItemId::X82 && itemId != (u8)game::ItemId::None) {

--- a/code/source/rnd/item_override.cpp
+++ b/code/source/rnd/item_override.cpp
@@ -39,7 +39,7 @@ namespace rnd {
     rItemOverrides[0].value.getItemId = 0x26;
     rItemOverrides[0].value.looksLikeItemId = 0x26;
     rItemOverrides[1].key.scene = 0x6C;
-    rItemOverrides[1].key.type = ItemOverride_Type::OVR_CHEST;
+    rItemOverrides[1].key.type = ItemOverride_Type::OVR_COLLECTABLE;
     rItemOverrides[1].value.getItemId = 0xB2;
     rItemOverrides[1].value.looksLikeItemId = 0xB2;
     rItemOverrides[2].key.scene = 0x12;
@@ -177,7 +177,7 @@ namespace rnd {
       }
       if (rPendingOverrideQueue[i].key.all == override.key.all) {
         // Prevent duplicate entries
-        // break;
+        break;
       }
     }
   }
@@ -533,6 +533,21 @@ namespace rnd {
       ItemOverride_PushPendingFairyRewardItem(gctx, fromActor, 0x3B);
       return;
     }
+  }
+
+  void ItemOverride_GetSoHItem(game::GlobalContext* gctx, game::act::Actor* fromActor, s16 incomingItemId) {
+#if defined ENABLE_DEBUG || defined DEBUG_PRINT
+    rnd::util::Print("%s: Song of healing item is now being obtained. Item ID is %i\n", __func__, incomingItemId);
+#endif
+    if (incomingItemId == 0x7A) {
+      gExtSaveData.mikauReward = 1;
+    } else if (incomingItemId == 0x79) {
+      gExtSaveData.darmaniReward = 1;
+    } else if (incomingItemId == 0x87) {
+      gExtSaveData.mummyDaddyReward = 1;
+    }
+    ItemOverride_GetItem(gctx, fromActor, gctx->GetPlayerActor(), incomingItemId);
+    return;
   }
 
   void ItemOverride_RemoveTextId() {

--- a/code/source/rnd/item_override.cpp
+++ b/code/source/rnd/item_override.cpp
@@ -565,10 +565,15 @@ namespace rnd {
       return (int)0xFF;
     } else if (currentItem == game::ItemId::BremenMask && gExtSaveData.givenItemChecks.enGuruGuruGivenItem == 0) {
       return (int)0xFF;
-    }  else if (currentItem == game::ItemId::KamaroMask && gExtSaveData.givenItemChecks.enYbGivenItem == 0) {
-        return (int)0xFF;
+    } else if (currentItem == game::ItemId::KamaroMask && gExtSaveData.givenItemChecks.enYbGivenItem == 0) {
+      return (int)0xFF;
     } else if (currentItem == game::ItemId::DonGeroMask && gExtSaveData.givenItemChecks.enGegGivenItem == 0) {
-        return (int)0xFF;
+      return (int)0xFF;
+    } else if (currentItem == game::ItemId::ZoraMask && gExtSaveData.givenItemChecks.enZogGivenItem == 0) {
+#if defined ENABLE_DEBUG || defined DEBUG_PRINT
+      rnd::util::Print("%s: Zog is still 0.\n", __func__);
+#endif
+      return (int)0xFF;
     }
 
     return (int)currentItem;

--- a/code/source/rnd/item_override.cpp
+++ b/code/source/rnd/item_override.cpp
@@ -464,7 +464,7 @@ namespace rnd {
       ItemTable_CallEffect(rActiveItemRow);
       gctx->ShowMessage(textId, actor);
       // Get_Item_Handler. Don't give ice traps, since it may cause UB.
-      if (itemId != (u8)game::ItemId::X82) {
+      if (itemId != (u8)game::ItemId::X82 && itemId != (u8)game::ItemId::None) {
         rnd::util::GetPointer<int(game::GlobalContext*, game::ItemId)>(0x233BEC)(gctx, (game::ItemId)itemId);
       }
       ItemOverride_AfterItemReceived();

--- a/code/source/rnd/item_override.cpp
+++ b/code/source/rnd/item_override.cpp
@@ -556,15 +556,21 @@ namespace rnd {
 
   int ItemOverride_CheckInventoryItemOverride(game::ItemId currentItem) {
     if (currentItem == game::ItemId::BlastMask) {
-      if (gExtSaveData.grannyGaveReward == 0)
-        return 0xFF;
+      if (gExtSaveData.grannyGaveReward == 0) {
+#if defined ENABLE_DEBUG || defined DEBUG_PRINT
+        rnd::util::Print("%s: Checking inventory current item is %04x and granny reward is %u\n", __func__, currentItem,
+                         gExtSaveData.grannyGaveReward);
+#endif
+        return (int)0xFF;
+      }
+
       else
         return (int)currentItem;
     } else if (currentItem == game::ItemId::DonGeroMask) {
       return (int)currentItem;
     }
 
-    return 0xFF;
+    return (int)currentItem;
   }
   }
 }  // namespace rnd

--- a/code/source/rnd/savefile.cpp
+++ b/code/source/rnd/savefile.cpp
@@ -740,11 +740,13 @@ namespace rnd {
 #endif
     // TODO: BitField for event flags instead?
     // memset(&gExtSaveData.extInf, 0, sizeof(gExtSaveData.extInf));
-    memset(&gExtSaveData.aromaGivenItem, 0, sizeof(gExtSaveData.aromaGivenItem));
-    memset(&gExtSaveData.grannyGaveReward, 0, sizeof(gExtSaveData.grannyGaveReward));
+    memset(&gExtSaveData.givenItemChecks.raw, 0, sizeof(gExtSaveData.givenItemChecks.raw));
+    /*memset(&gExtSaveData.aromaGivenItem, 0, sizeof(gExtSaveData.aromaGivenItem));
+    memset(&gExtSaveData.enBabaGivenItem, 0, sizeof(gExtSaveData.enBabaGivenItem));
+    memset(&gExtSaveData.stoneMaskReward, 0, sizeof(gExtSaveData.stoneMaskReward));
     memset(&gExtSaveData.mummyDaddyReward, 0, sizeof(gExtSaveData.mummyDaddyReward));
-    memset(&gExtSaveData.mikauReward, 0, sizeof(gExtSaveData.mikauReward));
-    memset(&gExtSaveData.darmaniReward, 0, sizeof(gExtSaveData.darmaniReward));
+    memset(&gExtSaveData.enZogGivenItem, 0, sizeof(gExtSaveData.enZogGivenItem));
+    memset(&gExtSaveData.darmaniReward, 0, sizeof(gExtSaveData.darmaniReward));*/
     gExtSaveData.fairyRewards.raw = 0;
     gExtSaveData.playtimeSeconds = 0;
     // TODO: Settings options belong in ext.

--- a/code/source/rnd/savefile.cpp
+++ b/code/source/rnd/savefile.cpp
@@ -22,6 +22,7 @@ namespace rnd {
 #endif
 #ifdef ENABLE_DEBUG
     saveData.equipment.sword_shield.sword = game::SwordType::GildedSword;
+    saveData.equipment.sword_shield.shield = game::ShieldType::MirrorShield;
     saveData.player.razor_sword_hp = 0x64;
     saveData.inventory.inventory_count_register.quiver_upgrade = game::Quiver::Quiver50;
     saveData.inventory.inventory_count_register.bomb_bag_upgrade = game::BombBag::BombBag40;
@@ -135,9 +136,10 @@ namespace rnd {
       gSettingsContext.startingDekuMask = 1;  // start with Deku Mask, Song of Healing & Bomber's notebook always
       saveData.inventory.collect_register.song_of_healing = 1;  // until happy mask salesman is overridden
       saveData.player.owl_statue_flags.clock_town = 1;
-      // gSettingsContext.startingKokiriSword = 1;
-      // gSettingsContext.startingShield = 1;
-
+#ifdef ENABLE_DEBUG
+      gSettingsContext.startingKokiriSword = 2;
+      gSettingsContext.startingShield = 2;
+#endif
       SaveFile_SetStartingInventory();
 
       // These events replay after song of time

--- a/code/source/rnd/savefile.cpp
+++ b/code/source/rnd/savefile.cpp
@@ -217,10 +217,10 @@ namespace rnd {
   void SaveFile_SetFastAnimationFlags() {
     game::SaveData& saveData = game::GetCommonData().save;
     // Masks
-    saveData.set_fast_mask_animations.has_worn_deku_mask_once = 1;
-    saveData.set_fast_mask_animations.has_worn_goron_mask_once = 1;
-    saveData.set_fast_mask_animations.has_worn_zora_mask_once = 1;
-    saveData.set_fast_mask_animations.has_worn_deity_mask_once = 1;
+    saveData.have_worn_mask_once.has_worn_deku_mask_once = 1;
+    saveData.have_worn_mask_once.has_worn_goron_mask_once = 1;
+    saveData.have_worn_mask_once.has_worn_zora_mask_once = 1;
+    saveData.have_worn_mask_once.has_worn_deity_mask_once = 1;
     // Dungeons
     saveData.set_fast_animation_flags.woodfall_temple_opened_at_least_once = 1;
     saveData.set_fast_animation_flags.snowhead_temple_opened_at_least_once = 1;
@@ -742,6 +742,9 @@ namespace rnd {
     // memset(&gExtSaveData.extInf, 0, sizeof(gExtSaveData.extInf));
     memset(&gExtSaveData.aromaGivenItem, 0, sizeof(gExtSaveData.aromaGivenItem));
     memset(&gExtSaveData.grannyGaveReward, 0, sizeof(gExtSaveData.grannyGaveReward));
+    memset(&gExtSaveData.mummyDaddyReward, 0, sizeof(gExtSaveData.mummyDaddyReward));
+    memset(&gExtSaveData.mikauReward, 0, sizeof(gExtSaveData.mikauReward));
+    memset(&gExtSaveData.darmaniReward, 0, sizeof(gExtSaveData.darmaniReward));
     gExtSaveData.fairyRewards.raw = 0;
     gExtSaveData.playtimeSeconds = 0;
     // TODO: Settings options belong in ext.

--- a/code/source/rnd/savefile.cpp
+++ b/code/source/rnd/savefile.cpp
@@ -47,7 +47,7 @@ namespace rnd {
 
     saveData.inventory.masks[5] = game::ItemId::DekuMask;
     saveData.inventory.masks[11] = game::ItemId::GoronMask;
-    saveData.inventory.masks[17] = game::ItemId::ZoraMask;
+    //saveData.inventory.masks[17] = game::ItemId::ZoraMask;
     saveData.inventory.masks[23] = game::ItemId::FierceDeityMask;
     saveData.inventory.masks[19] = game::ItemId::GibdoMask;
     saveData.inventory.masks[8] = game::ItemId::BunnyHood;
@@ -101,7 +101,7 @@ namespace rnd {
     saveData.inventory.collect_register.song_of_soaring = 1;
     saveData.inventory.collect_register.song_of_time = 1;
     // saveData.inventory.collect_register.oath_to_order = 1;
-    // saveData.inventory.collect_register.song_of_healing = 1;
+    saveData.inventory.collect_register.song_of_healing = 1;
 
     gSettingsContext.skipBombersMinigame = 1;
     gSettingsContext.freeScarecrow = 1;
@@ -411,8 +411,6 @@ namespace rnd {
 
     if (gSettingsContext.startingHerosBow > 0) {
       saveData.inventory.items[1] = game::ItemId::Arrow;
-      saveData.inventory.items[1] = game::ItemId::Arrow;
-      saveData.inventory.item_counts[6] = (gSettingsContext.startingHerosBow + 2) * 10;
       saveData.inventory.inventory_count_register.quiver_upgrade = game::Quiver::Quiver30;
       saveData.inventory.item_counts[6] = (gSettingsContext.startingHerosBow) * 10;
     } else if (gSettingsContext.startingHerosBow > 1) {
@@ -666,8 +664,7 @@ namespace rnd {
     }
 
     if (gSettingsContext.startingDoubleDefense) {
-      game::CommonData& cdata = game::GetCommonData();
-      ItemEffect_GiveDefense(&cdata, 0, 0);
+      playerData.double_defense = 1;
     }
 
 #ifdef ENABLE_DEBUG

--- a/code/source/rnd/savefile.cpp
+++ b/code/source/rnd/savefile.cpp
@@ -50,7 +50,7 @@ namespace rnd {
     saveData.inventory.masks[11] = game::ItemId::GoronMask;
     // saveData.inventory.masks[17] = game::ItemId::ZoraMask;
     saveData.inventory.masks[23] = game::ItemId::FierceDeityMask;
-    saveData.inventory.masks[19] = game::ItemId::GibdoMask;
+    saveData.inventory.masks[19] = game::ItemId::StoneMask;
     saveData.inventory.masks[8] = game::ItemId::BunnyHood;
     saveData.inventory.masks[20] = game::ItemId::GaroMask;
     saveData.inventory.masks[6] = game::ItemId::AllNightMask;
@@ -474,14 +474,14 @@ namespace rnd {
       saveData.inventory.items[0] = game::ItemId::Ocarina;
     }
 
-  if (gSettingsContext.startingWallet == (u8)StartingWalletSetting::STARTINGWALLET_NONE) {
-       saveData.inventory.inventory_count_register.wallet_upgrade = 0; //might not be needed? 
+    if (gSettingsContext.startingWallet == (u8)StartingWalletSetting::STARTINGWALLET_NONE) {
+      saveData.inventory.inventory_count_register.wallet_upgrade = 0;  // might not be needed?
     } else if (gSettingsContext.startingWallet == (u8)StartingWalletSetting::STARTINGWALLET_ADULT) {
-         saveData.inventory.inventory_count_register.wallet_upgrade = 1;
+      saveData.inventory.inventory_count_register.wallet_upgrade = 1;
     } else if (gSettingsContext.startingWallet == (u8)StartingWalletSetting::STARTINGWALLET_GIANT) {
-         saveData.inventory.inventory_count_register.wallet_upgrade = 2;
+      saveData.inventory.inventory_count_register.wallet_upgrade = 2;
     } else if (gSettingsContext.startingWallet == (u8)StartingWalletSetting::STARTINGWALLET_TYCOON) {
-         saveData.inventory.inventory_count_register.wallet_upgrade = 2;//2 for now until tycoon is added
+      saveData.inventory.inventory_count_register.wallet_upgrade = 2;  // 2 for now until tycoon is added
     }
     if (gSettingsContext.startingKokiriSword == (u8)StartingSwordSetting::STARTINGSWORD_NONE) {
       equipmentData.sword_shield.sword = game::SwordType::NoSword;

--- a/code/source/rnd/savefile.cpp
+++ b/code/source/rnd/savefile.cpp
@@ -134,8 +134,9 @@ namespace rnd {
       gSettingsContext.startingOcarina = 1;
       gSettingsContext.startingDekuMask = 1;  // start with Deku Mask, Song of Healing & Bomber's notebook always
       saveData.inventory.collect_register.song_of_healing = 1;  // until happy mask salesman is overridden
-      gSettingsContext.startingKokiriSword = 1;
-      gSettingsContext.startingShield = 1;
+      saveData.player.owl_statue_flags.clock_town = 1;
+      // gSettingsContext.startingKokiriSword = 1;
+      // gSettingsContext.startingShield = 1;
 
       SaveFile_SetStartingInventory();
 

--- a/code/source/rnd/savefile.cpp
+++ b/code/source/rnd/savefile.cpp
@@ -474,6 +474,15 @@ namespace rnd {
       saveData.inventory.items[0] = game::ItemId::Ocarina;
     }
 
+  if (gSettingsContext.startingWallet == (u8)StartingWalletSetting::STARTINGWALLET_NONE) {
+       saveData.inventory.inventory_count_register.wallet_upgrade = 0; //might not be needed? 
+    } else if (gSettingsContext.startingWallet == (u8)StartingWalletSetting::STARTINGWALLET_ADULT) {
+         saveData.inventory.inventory_count_register.wallet_upgrade = 1;
+    } else if (gSettingsContext.startingWallet == (u8)StartingWalletSetting::STARTINGWALLET_GIANT) {
+         saveData.inventory.inventory_count_register.wallet_upgrade = 2;
+    } else if (gSettingsContext.startingWallet == (u8)StartingWalletSetting::STARTINGWALLET_TYCOON) {
+         saveData.inventory.inventory_count_register.wallet_upgrade = 2;//2 for now until tycoon is added
+    }
     if (gSettingsContext.startingKokiriSword == (u8)StartingSwordSetting::STARTINGSWORD_NONE) {
       equipmentData.sword_shield.sword = game::SwordType::NoSword;
       saveData.equipment.data->item_btn_b = game::ItemId::None;

--- a/code/source/rnd/savefile.cpp
+++ b/code/source/rnd/savefile.cpp
@@ -47,7 +47,7 @@ namespace rnd {
 
     saveData.inventory.masks[5] = game::ItemId::DekuMask;
     saveData.inventory.masks[11] = game::ItemId::GoronMask;
-    //saveData.inventory.masks[17] = game::ItemId::ZoraMask;
+    // saveData.inventory.masks[17] = game::ItemId::ZoraMask;
     saveData.inventory.masks[23] = game::ItemId::FierceDeityMask;
     saveData.inventory.masks[19] = game::ItemId::GibdoMask;
     saveData.inventory.masks[8] = game::ItemId::BunnyHood;


### PR DESCRIPTION
This PR now enables overrides for Mikau and the Mummy Daddy Gibdo Mask item Overrides.

Behind the scenes we swapped item rewards in extdata to use BitFields instead of a series of `s8`s to save on some space.

Also fixed double defense (and any item that gives Item::None) from removing the Ocarina from inventory.

Starting rupees have also been fixed as well for the wallet.