### PR TITLE
Darmani Give Item

### DIFF
--- a/code/include/game/common_data.h
+++ b/code/include/game/common_data.h
@@ -241,36 +241,36 @@ namespace game {
     u8 boss_started_flags;
     u8 more_boss_start_flags;
     char anonymous_16;
-    char gap33[205];
+    char gap2b[205];
     char anonymous_a[24];  // Possible permanent scene flags? Could be put in the gap to match 0x1C
                            // size?
     char anonymous_b;
-    u8 gap_115[7];
+    u8 gap111[7];
     PlayerData player;
     EquipmentData equipment;
     InventoryData inventory;
-    char field_24C;
-    u8 gap241[868];
+    char field_248;
+    u8 gap249[868];
     u8 tatl_dialogue_inside_woodfall_temple_0x80;
-    u8 gap5B6[62];
+    u8 gap5AE[62];
     u8 removes_sunblock_at_ikana_castle_entrance_0x08;
-    u8 gap5F5[6];
+    u8 gap5ED[6];
     u8 ikana_castle_camera_pan_0x08;
-    u8 gap5FC[123];
+    u8 gap5F4[123];
     u8 snowhead_temple_main_room_camera_pan_0x01;
-    u8 gap678[67];
+    u8 gap670[67];
     u8 pirate_leader_dialogue_0x20;
-    u8 gap6BC[103];
+    u8 gap6BC[104];
     int anonymous_44;
-    u8 gap728[204];
+    u8 gap720[204];
     u8 skullkid_backstory_cutscene_0x10;
     u8 gap7F5[178];
     char anonymous_45;
-    u8 gap8A9[269];
+    u8 gap8A1[269];
     u8 pirates_fortress_exterior_camera_pan_0x04;
-    u8 gap9B6[350];
+    u8 gap9AF[350];
     u8 woodfall_platform_tatl_dialogue_0x02;
-    u8 gapB15[95];
+    u8 gapB0E[95];
     union TatlDialogueGreatBayTemple {
       u8 raw;
 
@@ -280,19 +280,19 @@ namespace game {
       BitField<7, 1, u8> unknown;
     };
     TatlDialogueGreatBayTemple talt_dialogue_great_bay_temple;
-    u8 gapB75[304];
+    u8 gapB6E[306];
     int anonymous_46;
-    u8 gapCAC[297];
+    u8 gapCA4[297];
     u8 tatl_dialogue_snowhead_entry_0x08;
-    u8 gapDD6[222];
+    u8 gapDCE[222];
     u8 meeting_happy_mask_salesman_0x01;
-    u8 gapEB5[762];
+    u8 gapEAD[763];
     int anonymous_47;
     int anonymous_48;
     int anonymous_49;
     int anonymous_50;
     int anonymous_51;
-    u8 gap11C4[12];
+    u8 gap11BC[12];
     int anonymous_52;
     int anonymous_53;
     int anonymous_54;
@@ -300,9 +300,9 @@ namespace game {
     int anonymous_56;
     int anonymous_57;
     int anonymous_58;
-    u8 gap11EC[4];
+    u8 gap11E4[4];
     u8 overworld_map_data[15];
-    u8 gap11FF[17];
+    u8 gap11F7[17];
     union SkulltulaRegister {
       u32 raw;
 
@@ -311,22 +311,22 @@ namespace game {
     };
     SkulltulaRegister skulltulas_collected;
     int anonymous_60;
-    u8 gap1218[4];
-    u8 defeated_bosses[4];      // like a history log of deafeated bosses or seen giants
-    u8 previous_defeated_boss;  // or last viewed giant cutscene, values 4 and greater makes
-                                // woodfall giant repeat for all temples.
-    u8 gap1221[3];
+    u8 gap1210[4];
+    u8 defeated_bosses[4];       // like a history log of deafeated bosses or seen giants
+    int previous_defeated_boss;  // or last viewed giant cutscene, values 4 and greater makes
+                                 // woodfall giant repeat for all temples.
+    // u8 gap1221[3];
     int anonymous_63;
-    u8 gap1228[8];
+    u8 gap1220[8];
     u16 bank_rupee_count;
     u16 anonymous_64;
-    u8 gap1234[8];
+    u8 gap122C[8];
     int anonymous_65;
     int anonymous_66;
     u16 player_guessed_lottery_numbers;
     u16 anonymous_67;
     int anonymous_68;
-    u8 gap124C[4];
+    u8 gap1244[4];
     union CameraPanningEventFlags {
       u32 raw;
 
@@ -363,7 +363,7 @@ namespace game {
       BitField<27, 5, u32> unknown4;
     };
     CameraPanningEventFlags camera_panning_event_flag_bundle;
-    u8 gap1254[3];
+    u8 gap124C[3];
     char tatl_apology_dialogue_post_Odolwa_0x80;
     char anonymous_72;
     char anonymous_73;
@@ -417,11 +417,11 @@ namespace game {
     char anonymous_102;
     char anonymous_103;
     char anonymous_104;
-    u8 gap127A[8];
+    u8 gap1272[8];
     char anonymous_105;
     char anonymous_106;
     char anonymous_107;
-    union MoreEventFlags {
+    union GreatBayEventFlags {
       u8 raw;
 
       BitField<0, 5, u8> unknown1;
@@ -429,7 +429,7 @@ namespace game {
       BitField<6, 1, u8> skip_swimming_to_great_bay_temple_cutscene;
       BitField<7, 1, u8> unknown2;
     };
-    MoreEventFlags event_flag_bundle;
+    GreatBayEventFlags turtle_flags;
     char anonymous_109;
     char anonymous_110;
     char anonymous_111;
@@ -442,8 +442,8 @@ namespace game {
     char anonymous_118;
     char anonymous_119;
     char anonymous_120;
-    u8 gap1292[7];
-    union TempEventFlags {
+    u8 gap128A[7];
+    union ClockTownResetFlags {
       u8 raw;
 
       BitField<0, 2, u8> unknown1;
@@ -451,7 +451,7 @@ namespace game {
       BitField<2, 4, u8> unknown2;
       BitField<7, 1, u8> bomber_open_hideout;
     };
-    TempEventFlags temp_event_flag_bundle1;
+    ClockTownResetFlags clock_town_temp_flags;
     char anonymous_122;
     u8 anju_0x10_if_obtained_small_key;
     char anonymous_124;
@@ -475,21 +475,22 @@ namespace game {
       BitField<6, 1, u8> go_east;
       BitField<7, 1, u8> go_to_skullkid;
     };
-    TatlDialogueFlags tatl_dialogue_flags1;
+    TatlDialogueFlags tatl_dialogue_direction_to_go;
     u8 mikau_pushed_to_shore_0x10;
     char anonymous_137;
     char anonymous_138;
     u8 mikau_dialogue_flags_0x03;
     char anonymous_140;
     char anonymous_141;
-    u8 gap12AE[6];
+    u8 SoH_Talked_To_Actor_Bitflag;
+    u8 gap12A7[5];
     char anonymous_142;
     char anonymous_143;
     char anonymous_144;
-    u8 gap12B7[3];
+    u8 gap12AF[3];
     char anonymous_145;
     char anonymous_146;
-    u8 gap12BC[13];
+    u8 gap12B4[13];
     char anonymous_147;
     char anonymous_148[6];
     char anonymous_149;
@@ -512,7 +513,7 @@ namespace game {
     char anonymous_156;
     char anonymous_157;
     u8 road_to_woodfall_camera_pan_0x08;
-    union SetFastAnimationFlags {
+    union OpenedTempleFlags {
       u8 raw;
 
       BitField<0, 3, u8> unknown1;
@@ -522,9 +523,9 @@ namespace game {
       BitField<6, 1, u8> greatbay_temple_opened_at_least_once;
       BitField<7, 1, u8> deku_flown_in_at_least_once;
     };
-    SetFastAnimationFlags set_fast_animation_flags;
+    OpenedTempleFlags opened_temple_once_flags;
     char anonymous_160;
-    u8 gap12DC[20];
+    u8 gap12D4[20];
     // Possibly flags for locations visted or game progression counter
     // Did not affect cutscenes
     int unknown_flags_0x12F0;
@@ -542,7 +543,7 @@ namespace game {
     u8 winning_lottery_numbers_day_2[3];
     u8 winning_lottery_numbers_day_3[3];
     char anonymous_179;
-    u8 gap138A[5];
+    u8 gap1382[5];
     u8 bomberscode[5];
     char anonymous_185;
     char anonymous_186[3];
@@ -551,7 +552,9 @@ namespace game {
     u16 anonymous_189;
     u16 anonymous_190;
     u16 anonymous_191;
-    u8 gap13A2[326];
+    u8 gap139A[294];
+    u8 field_14BD[28];
+    u8 gap_14DC[4];
     char num_ftickets_rank10;
     char anonymous_193;
     char anonymous_194;
@@ -569,7 +572,7 @@ namespace game {
     u16 anonymous_201;
     u8 order_of_equip_items_in_inventory[20];
     u8 order_of_masks_in_inventory[24];
-    u8 gap1A5C[8];
+    u8 gap1A54[8];
     u16 anonymous_226;
     char anonymous_227[2];
     u8 gap_1A60[16];
@@ -580,6 +583,7 @@ namespace game {
     int field_1A84;
   };
   static_assert(sizeof(SaveData) == 0x1A88);
+  static_assert(offsetof(SaveData, gap1382) == 0x1382);
 
   struct CommonDataSub1 {
     int entrance;

--- a/code/include/game/context.h
+++ b/code/include/game/context.h
@@ -100,6 +100,7 @@ namespace game {
     SongOfStorms = 10,
     InvertedSongOfTime = 12,
     SongOfDoubleTime = 13,
+    ScarecrowSong = 21,
 
     InvalidDetecting = 0xfe,
     Invalid = 0xff,

--- a/code/include/game/items.h
+++ b/code/include/game/items.h
@@ -146,8 +146,8 @@ namespace game {
     HeartContainer = 0x6f,
     PieceOfHeart = 0x70,
 
-    X71 = 0x71,
-    X72 = 0x72,
+    InvertedSongOfTime = 0x71,
+    SongOfDoubleTime = 0x72,
     X73 = 0x73,
 
     BossKey = 0x74,

--- a/code/mm.ld
+++ b/code/mm.ld
@@ -25,8 +25,8 @@ SECTIONS{
     *(.patch_DecoupleStartSelect)
   }
 
-  .patch_RemoveMessageZoraMaskMaybeMore 0x186810 : {
-    *(.patch_RemoveMessageZoraMaskMaybeMore)
+  .patch_RemoveSOSCutesceneAfterMessage 0x186810 : {
+    *(.patch_RemoveSOSCutesceneAfterMessage)
   }
 
   .patch_RemoveMysteryMilkTimer 0x1B7A54 : {
@@ -77,15 +77,6 @@ SECTIONS{
 		*(.patch_DisableMilkTimer)
 	}
 
-  .patch_LoadExtData 0x48C760 : {
-    *(.patch_LoadExtData)
-  }
-
-  /*0x05ffc70*/ /*0x177ddc*/ /*0x5bbab8 */ /* 0x5b8b24 */
-	.patch_SaveFile_init 0x5b8b24 : {
-		*(.patch_SaveFile_init)
-	}
-
   .patch_FixSurroundSound 0x1404E8 : {
     *(.patch_FixSurroundSound)
   }
@@ -106,7 +97,7 @@ SECTIONS{
     *(.patch_ISGCrouchStabOne)
   }
 
-  .patch_RemoveMysteryMilkSoSCheck 0x1d79f8 : {
+  .patch_RemoveMysteryMilkSoSCheck 0x1D79F8 : {
     *(.patch_RemoveMysteryMilkSoSCheck)
   }
 
@@ -134,14 +125,6 @@ SECTIONS{
     *(.patch_OverrideItemID)
   }
 
-  .patch_OverrideFairyGiveItem 0x3becac : {
-    *(.patch_OverrideFairyGiveItem)
-  }
-
-  .patch_OverrideGreatFairySpawn 0x3bec84 : {
-    *(.patch_OverrideGreatFairySpawn)
-  }
-
   .patch_TwinmoldConsistentDamage 0x28E544 : {
     *(.patch_TwinmoldConsistentDamage)
   }
@@ -152,6 +135,18 @@ SECTIONS{
 
   .patch_FasterBlockMovementBack 0x2D0C0C : {
     *(.patch_FasterBlockMovementBack)
+  }
+
+  .patch_RemoveGoronMaskCheckDarmani 0x2DE788 : {
+    *(.patch_RemoveGoronMaskCheckDarmani)
+  }
+
+  .patch_OverrideFairyGiveItem 0x3becac : {
+    *(.patch_OverrideFairyGiveItem)
+  }
+
+  .patch_OverrideGreatFairySpawn 0x3bec84 : {
+    *(.patch_OverrideGreatFairySpawn)
   }
 
   .patch_SaveExtDataOnOwl 0x317004 : {
@@ -166,6 +161,10 @@ SECTIONS{
     *(.patch_AromaItemCheck)
   }
 
+  .patch_GoronMaskGiveItem 0x41DAB0 : {
+    *(.patch_GoronMaskGiveItem)
+  }
+
   .patch_ZoraMaskGiveItem 0x41DB80 : {
     *(.patch_ZoraMaskGiveItem)
   }
@@ -175,6 +174,10 @@ SECTIONS{
 
   .patch_GibdoMaskGiveItem 0x41DC48 : {
     *(.patch_GibdoMaskGiveItem)
+  }
+
+  .patch_LoadExtData 0x48C760 : {
+    *(.patch_LoadExtData)
   }
 
   .patch_IncomingGetItemID 0x4B1394 : {
@@ -188,6 +191,11 @@ SECTIONS{
   .patch_DisableExistingTrigger 0x59BA14 : {
     *(.patch_DisableExistingTrigger)
   }
+
+  /*0x05ffc70*/ /*0x177ddc*/ /*0x5bbab8 */ /* 0x5b8b24 */
+	.patch_SaveFile_init 0x5b8b24 : {
+		*(.patch_SaveFile_init)
+	}
 
   .patch_ItemCloseOnSelect 0x5C19E4 : {
     *(.patch_ItemCloseOnSelect)

--- a/code/mm.ld
+++ b/code/mm.ld
@@ -168,9 +168,10 @@ SECTIONS{
   .patch_ZoraMaskGiveItem 0x41DB80 : {
     *(.patch_ZoraMaskGiveItem)
   }
-  .patch_RemoveZoraMaskAppearing 0x41DB98 : {
-    *(.patch_RemoveZoraMaskAppearing)
-  }
+
+  /* .patch_RemoveSoHMaskAppearing 0x41DB98 : {
+    *(.patch_RemoveSoHMaskAppearing)
+  } */
 
   .patch_GibdoMaskGiveItem 0x41DC48 : {
     *(.patch_GibdoMaskGiveItem)

--- a/code/mm.ld
+++ b/code/mm.ld
@@ -25,8 +25,8 @@ SECTIONS{
     *(.patch_DecoupleStartSelect)
   }
 
-  .patch_RemoveSOSCutesceneAfterMessage 0x186810 : {
-    *(.patch_RemoveSOSCutesceneAfterMessage)
+  .patch_RemoveSOHCutesceneAfterMessage 0x186810 : {
+    *(.patch_RemoveSOHCutesceneAfterMessage)
   }
 
   .patch_RemoveMysteryMilkTimer 0x1B7A54 : {

--- a/code/source/asm/hooks.s
+++ b/code/source/asm/hooks.s
@@ -20,6 +20,12 @@ hook_MainLoop:
     ldr r1, [r0,#0x138]
     b 0x0106770
 
+.global hook_ChangeSOHToCustomText
+hook_ChangeSOHToCustomText:
+    push {r0-r2, lr}
+    bl ItemOverride_SwapSoHGetItemText
+    pop {r0-r2, lr}
+    b 0x186814
 
 .global hook_SpawnFastElegyStatues
 hook_SpawnFastElegyStatues:

--- a/code/source/asm/hooks.s
+++ b/code/source/asm/hooks.s
@@ -161,6 +161,18 @@ noOverrideItemID:
     b 0x23110C
 
 
+.global hook_DarmaniRewardCheck
+hook_DarmaniRewardCheck:
+    push {r0-r12, lr}
+    bl ItemOverride_CheckDarmaniGivenItem
+    cmp r0,#0x1
+    pop {r0-r12, lr}
+    beq doNotSpawnDarmani
+    b 0x2DE794
+doNotSpawnDarmani:
+    nop
+    b 0x2DE96C
+
 .global hook_IncomingGetItemID
 hook_IncomingGetItemID:
     push {r0-r12, lr}
@@ -221,6 +233,30 @@ hook_AromaItemCheck:
     cmp r0,#0x1
     pop {r0-r12, lr}
     b 0x350920
+
+.global hook_GoronMaskGiveItem
+hook_GoronMaskGiveItem:
+    push {r0-r12, lr}
+    cpy r0,r5
+    cpy r1,r4
+    mov r2,#0x7A
+    bl ItemOverride_GetSoHItem
+    ldr r5,.rActiveItemRow_addr
+    ldr r5,[r5]
+    cmp r5,#0x0
+    pop {r0-r12, lr}
+    beq noOverrideDarmaniItemID
+    push {r0-r12, lr}
+    cpy r0,r5
+    cpy r1,r4
+    bl ItemOverride_GetItemTextAndItemID
+    pop {r0-r12, lr}
+    cpy r0,r5
+    b 0x41DAB4
+noOverrideDarmaniItemID:
+    cpy r0,r5
+    bl 0x233BEC
+    b 0x41DAB4
 
 .global hook_ZoraMaskGiveItem
 hook_ZoraMaskGiveItem:

--- a/code/source/asm/patches.s
+++ b/code/source/asm/patches.s
@@ -252,9 +252,9 @@ patch_GoronMaskGiveItem:
 patch_ZoraMaskGiveItem:
     b hook_ZoraMaskGiveItem
 
-.section .patch_RemoveZoraMaskAppearing
-.global patch_RemoveZoraMaskAppearing
-patch_RemoveZoraMaskAppearing:
+.section .patch_RemoveSoHMaskAppearing
+.global patch_RemoveSoHMaskAppearing
+patch_RemoveSoHMaskAppearing:
     nop
     
 .section .patch_GibdoMaskGiveItem

--- a/code/source/asm/patches.s
+++ b/code/source/asm/patches.s
@@ -52,10 +52,11 @@ patch_DecoupleStartSelect:
 @ This should remove the overwriting message for when the
 @ user receives the Zora Mask.
 @ Largely untested, need to check for any UB.
-.section .patch_RemoveSOSCutesceneAfterMessage
-.global patch_RemoveSOSCutesceneAfterMessage
-patch_RemoveSOSCutesceneAfterMessage:
-    nop
+.section .patch_RemoveSOHCutesceneAfterMessage
+.global patch_RemoveSOHCutesceneAfterMessage
+patch_RemoveSOHCutesceneAfterMessage:
+    b hook_ChangeSOHToCustomText
+@nop
 
 @ There's a while loop located in the event
 @ timer that checks if we have mystery milk.

--- a/code/source/asm/patches.s
+++ b/code/source/asm/patches.s
@@ -52,9 +52,9 @@ patch_DecoupleStartSelect:
 @ This should remove the overwriting message for when the
 @ user receives the Zora Mask.
 @ Largely untested, need to check for any UB.
-.section .patch_RemoveMessageZoraMaskMaybeMore
-.global patch_RemoveMessageZoraMaskMaybeMore
-patch_RemoveMessageZoraMaskMaybeMore:
+.section .patch_RemoveSOSCutesceneAfterMessage
+.global patch_RemoveSOSCutesceneAfterMessage
+patch_RemoveSOSCutesceneAfterMessage:
     nop
 
 @ There's a while loop located in the event
@@ -171,6 +171,11 @@ OverrideBomberTextID_patch:
 OverrideItemID_patch:
     b hook_OverrideItemID
 
+.section .patch_RemoveGoronMaskCheckDarmani
+.global patch_RemoveGoronMaskCheckDarmani
+patch_RemoveGoronMaskCheckDarmani:
+    b hook_DarmaniRewardCheck
+
 .section .patch_OverrideFairyGiveItem
 .global OverrideFairyItemID_patch
 OverrideFairyItemID_patch:
@@ -236,6 +241,11 @@ patch_RemoveZoraMaskCheckMikau:
 .global patch_AromaItemCheck
 patch_AromaItemCheck:
     b hook_AromaItemCheck
+
+.section .patch_GoronMaskGiveItem
+.global patch_GoronMaskGiveItem
+patch_GoronMaskGiveItem:
+    b hook_GoronMaskGiveItem
 
 .section .patch_ZoraMaskGiveItem
 .global patch_ZoraMaskGiveItem

--- a/code/source/rnd/item_override.cpp
+++ b/code/source/rnd/item_override.cpp
@@ -28,6 +28,7 @@ namespace rnd {
   u32 rActiveItemObjectId = 0;
   u32 rActiveItemFastChest = 0;
   u16 rStoredBomberNoteTextId = 0;
+  u16 rActiveItemSoHTextId = 0;
 
   static u8 rSatisfiedPendingFrames = 10;
 
@@ -154,6 +155,7 @@ namespace rnd {
     rActiveItemRow = itemRow;
     rActiveItemActionId = itemRow->itemId;
     rActiveItemTextId = itemRow->textId;
+    rActiveItemSoHTextId = itemRow->textId;
     rActiveItemObjectId = itemRow->objectId;
     rActiveItemGraphicId = looksLikeItemId ? ItemTable_GetItemRow(looksLikeItemId)->graphicId : itemRow->graphicId;
     rActiveItemFastChest = (u32)itemRow->chestType & 0x01;
@@ -471,9 +473,11 @@ namespace rnd {
       u8 itemId = rActiveItemRow->itemId;
       ItemTable_CallEffect(rActiveItemRow);
 #if defined ENABLE_DEBUG || defined DEBUG_PRINT
-      rnd::util::Print("%s:Player Item ID is %#04x\n", __func__, actor->get_item_id);
+      rnd::util::Print("%s:Player Item ID is %#04x\nScene is %#04x", __func__, actor->get_item_id, gctx->scene);
 #endif
-      gctx->ShowMessage(textId, actor);
+      if (gctx->scene != game::SceneId::GoronGraveyard && gctx->scene != game::SceneId::GreatBayCoast &&
+          gctx->scene != game::SceneId::MusicBoxHouse)
+        gctx->ShowMessage(textId, actor);
       // Get_Item_Handler. Don't give ice traps, since it may cause UB.
       if (itemId != (u8)game::ItemId::None) {
         rnd::util::GetPointer<int(game::GlobalContext*, game::ItemId)>(0x233BEC)(gctx, (game::ItemId)itemId);
@@ -588,6 +592,15 @@ namespace rnd {
     }
 
     return (int)currentItem;
+  }
+  void ItemOverride_SwapSoHGetItemText(game::GlobalContext* gctx, u16 textId, game::act::Actor* fromActor) {
+    // Check which text ID is coming in. If it's any mask from Song of Healing, replace it with active item text.
+    if (textId == 0x79 || textId == 0x7a || textId == 0x87 || textId == 0x78 /*|| textId == 0x50*/)
+      gctx->ShowMessage(rActiveItemSoHTextId);
+    else
+      gctx->ShowMessage(textId);
+    rActiveItemSoHTextId = 0;
+    return;
   }
   }
 }  // namespace rnd

--- a/code/source/rnd/item_override.cpp
+++ b/code/source/rnd/item_override.cpp
@@ -475,7 +475,7 @@ namespace rnd {
 #endif
       gctx->ShowMessage(textId, actor);
       // Get_Item_Handler. Don't give ice traps, since it may cause UB.
-      if (itemId != (u8)game::ItemId::X82 && itemId != (u8)game::ItemId::None) {
+      if (itemId != (u8)game::ItemId::None) {
         rnd::util::GetPointer<int(game::GlobalContext*, game::ItemId)>(0x233BEC)(gctx, (game::ItemId)itemId);
       }
       ItemOverride_AfterItemReceived();

--- a/code/source/rnd/item_override.cpp
+++ b/code/source/rnd/item_override.cpp
@@ -443,6 +443,12 @@ namespace rnd {
     return false;
   }
 
+  bool ItemOverride_CheckDarmaniGivenItem() {
+    if (gExtSaveData.givenItemChecks.enGgGivenItem > 0)
+      return true;
+    return false;
+  }
+
   void ItemOverride_GetItemTextAndItemID(game::act::Player* actor) {
     if (rActiveItemRow != NULL) {
       if (rActiveItemOverride.key.type == ItemOverride_Type::OVR_CHEST) {

--- a/code/source/rnd/item_table.cpp
+++ b/code/source/rnd/item_table.cpp
@@ -119,7 +119,7 @@ namespace rnd {
                         (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_NONE,
                         (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1, (s16)-1),  // Get Fairy Text
 
-      [0x12] = ITEM_ROW((u32)GetItemID::GI_RUPEE_BLUE, ChestType::WOODEN_SMALL, (u8)game::ItemId::X82, 0x0012, 0x00FF,
+      [0x12] = ITEM_ROW((u32)GetItemID::GI_RUPEE_BLUE, ChestType::WOODEN_SMALL, (u8)game::ItemId::None, 0x0012, 0x00FF,
                         (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)0xFFFF,
                         (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_IceTrap, (s16)-1,
                         (s16)-1),  // Ice Trap

--- a/code/source/rnd/savefile.cpp
+++ b/code/source/rnd/savefile.cpp
@@ -47,7 +47,7 @@ namespace rnd {
     saveData.inventory.items[20] = game::ItemId::LandTitleDeed;
 
     saveData.inventory.masks[5] = game::ItemId::DekuMask;
-    saveData.inventory.masks[11] = game::ItemId::GoronMask;
+    // saveData.inventory.masks[11] = game::ItemId::GoronMask;
     // saveData.inventory.masks[17] = game::ItemId::ZoraMask;
     saveData.inventory.masks[23] = game::ItemId::FierceDeityMask;
     saveData.inventory.masks[19] = game::ItemId::StoneMask;
@@ -72,9 +72,9 @@ namespace rnd {
     saveData.inventory.stone_tower_dungeon_items.compass = 1;
     saveData.inventory.stone_tower_dungeon_items.boss_key = 1;
     saveData.inventory.woodfall_fairies = 14;
-    // saveData.player.magic_acquired = 1;  // Game does not check if value = 0, magic items still
+    saveData.player.magic_acquired = 1;  // Game does not check if value = 0, magic items still
     // work saveData.player.magic_size_type = 0; saveData.player.magic = 10;
-    // saveData.player.magic_num_upgrades = 0;
+    saveData.player.magic_num_upgrades = 0;
     saveData.equipment.data[3].item_btns[0] = game::ItemId::DekuNuts;
     saveData.inventory.item_counts[6] = 50;   // Arrows
     saveData.inventory.item_counts[11] = 40;  // Bombs

--- a/code/source/rnd/savefile.cpp
+++ b/code/source/rnd/savefile.cpp
@@ -146,7 +146,7 @@ namespace rnd {
       saveData.ct_guard_allows_through_if_0x20 = 0x20;
       saveData.tatl_dialogue_snowhead_entry_0x08 = 0x08;
       saveData.pirate_leader_dialogue_0x20 = 0x20;
-      saveData.temp_event_flag_bundle1.ct_deku_in_flower_if_present = 1;
+      saveData.clock_town_temp_flags.ct_deku_in_flower_if_present = 1;
       saveData.skip_tingle_intro_dialogue_0x01 = 0x01;
 
       saveData.player_form = game::act::Player::Form::Human;
@@ -193,10 +193,10 @@ namespace rnd {
     // Tatl constant tatling skip
     saveData.cut_scene_flag_bundle.tatl_moon_tear_dialogue = 1;
     saveData.tatl_dialogue_flags2.go_south = 1;
-    saveData.tatl_dialogue_flags1.go_north = 1;
-    saveData.tatl_dialogue_flags1.go_west = 1;
-    saveData.tatl_dialogue_flags1.go_east = 1;
-    saveData.tatl_dialogue_flags1.go_to_skullkid = 1;
+    saveData.tatl_dialogue_direction_to_go.go_north = 1;
+    saveData.tatl_dialogue_direction_to_go.go_west = 1;
+    saveData.tatl_dialogue_direction_to_go.go_east = 1;
+    saveData.tatl_dialogue_direction_to_go.go_to_skullkid = 1;
     saveData.woodfall_platform_tatl_dialogue_0x02 = 0x02;
     saveData.tatl_dialogue_inside_woodfall_temple_0x80 = 0x80;
     saveData.tatl_apology_dialogue_post_Odolwa_0x80 = 0x80;
@@ -211,7 +211,7 @@ namespace rnd {
     saveData.skullkid_backstory_cutscene_0x10 = 0x10;
     saveData.cut_scene_flag_bundle.owl_statue_cut_scene = 1;
     saveData.dungeon_skip_portal_cutscene_0x3C_to_skip_all = 0x3C;
-    saveData.event_flag_bundle.skip_swimming_to_great_bay_temple_cutscene = 1;
+    saveData.turtle_flags.skip_swimming_to_great_bay_temple_cutscene = 1;
 
     // Needs to be greater than zero to skip first time song of time cutscene
     saveData.player.song_of_time_counter = 1;
@@ -225,11 +225,11 @@ namespace rnd {
     saveData.have_worn_mask_once.has_worn_zora_mask_once = 1;
     saveData.have_worn_mask_once.has_worn_deity_mask_once = 1;
     // Dungeons
-    saveData.set_fast_animation_flags.woodfall_temple_opened_at_least_once = 1;
-    saveData.set_fast_animation_flags.snowhead_temple_opened_at_least_once = 1;
-    saveData.set_fast_animation_flags.greatbay_temple_opened_at_least_once = 1;
+    saveData.opened_temple_once_flags.woodfall_temple_opened_at_least_once = 1;
+    saveData.opened_temple_once_flags.snowhead_temple_opened_at_least_once = 1;
+    saveData.opened_temple_once_flags.greatbay_temple_opened_at_least_once = 1;
     // Misc
-    saveData.set_fast_animation_flags.deku_flown_in_at_least_once = 1;
+    saveData.opened_temple_once_flags.deku_flown_in_at_least_once = 1;
   }
 
   void SaveFile_SetStartingOwlStatues() {
@@ -267,7 +267,7 @@ namespace rnd {
       saveData.bomberscode[2] = 0x01;
       saveData.bomberscode[3] = 0x01;
       saveData.bomberscode[4] = 0x01;
-      saveData.temp_event_flag_bundle1.bomber_open_hideout = 1;  // Currently gets reset by Song of time
+      saveData.clock_town_temp_flags.bomber_open_hideout = 1;  // Currently gets reset by Song of time
     }
 
     // Game uses an inventory check to determine whether you can


### PR DESCRIPTION
Fixed some undefined behaviour with nopping out all the text boxes when the Song Of Healing was played. Instead, we just override the specific text box with the one we are given through the active item row.

Save structure has been updated to be inline with Ghidra, and vice-versa. Some event flags have been changed to be more generic and meaningful.

Reorganized the LD file to be sorted by addresses instead. Still will need to do the same with the patches file, and hooks.

