### PR TITLE
Mask fixes

### DIFF
--- a/code/include/game/actor.h
+++ b/code/include/game/actor.h
@@ -51,6 +51,8 @@ namespace game::act {
     NpcEnFsn = 0x0157,
     // Npc For Boat Photography
     NpcSwampPhotographer = 0x0158,
+    // NPC Postman
+    NpcEnPm = 0x0166,
     // Goht
     BossGoht = 0x016E,
     // [7] Owl statue

--- a/code/include/game/actor.h
+++ b/code/include/game/actor.h
@@ -35,6 +35,8 @@ namespace game::act {
     ObjElegyStatue = 0x1F,
     // Clear Tag (?)
     ClearTag = 0x73,
+    // Cursed Man Spider House
+    EnSsh = 0x90,
     // [1] Deku Palace / Woodfall Temple moving platforms (after player lands on them)
     ObjRailLift = 0xd8,
     // Shooting Gallery - Man

--- a/code/include/game/actor.h
+++ b/code/include/game/actor.h
@@ -37,6 +37,8 @@ namespace game::act {
     ClearTag = 0x73,
     // [1] Deku Palace / Woodfall Temple moving platforms (after player lands on them)
     ObjRailLift = 0xd8,
+    // Shooting Gallery - Man
+    EnSyatekiMan = 0xC2,
     // [9] Odolwa
     BossOdolwa = 0xcb,
     // [9] Twinmold (Red/Blue)
@@ -55,6 +57,8 @@ namespace game::act {
     NpcEnPm = 0x0166,
     // Goht
     BossGoht = 0x016E,
+    // Postbox
+    EnPst = 0x182,
     // [7] Owl statue
     ObjOwlStatue = 0x01B2,
     // [4] Old Lady from Bomb Shop

--- a/code/include/game/actor.h
+++ b/code/include/game/actor.h
@@ -49,6 +49,8 @@ namespace game::act {
     BossGyorg = 0xcd,
     // [4] Kafei
     NpcKafei = 0x00F4,
+    // Deku Butler
+    EnDno = 0x0117,
     // Ice platform created using ice arrows.
     BgIcePlatform = 0x013E,
     // Npc For Curiosity Shop Owner

--- a/code/include/rnd/item_effect.h
+++ b/code/include/rnd/item_effect.h
@@ -25,12 +25,10 @@ namespace rnd {
   void ItemEffect_GiveDoubleDefense(game::CommonData* comData, s16 arg1, s16 arg2);
   void ItemEffect_GiveOcarina(game::CommonData* comData, s16 arg1, s16 arg2);
   void ItemEffect_GiveSong(game::CommonData* comData, s16 questBit, s16 arg2);
-  void ItemEffect_PlaceMagicArrowsInInventory(game::CommonData* comData, s16 questBit, s16 arg2);
   void ItemEffect_GiveUpgrade(game::CommonData* comData, s16 arg1, s16 arg2);
   void ItemEffect_IceTrap(game::CommonData* comData, s16 arg1, s16 arg2);
   void ItemEffect_BeanPack(game::CommonData* comData, s16 arg1, s16 arg2);
   void ItemEffect_FillWalletUpgrade(game::CommonData* comData, s16 arg1, s16 arg2);
-  void ItemEffect_PlaceMagicArrowsInInventory(game::CommonData* comData, s16 arg1, s16 arg2);
   void ItemEffect_GiveRemains(game::CommonData* comData, s16 mask, s16 arg2);
   void ItemEffect_GiveMask(game::CommonData* comData, s16 mask, s16 arg2);
 }  // namespace rnd

--- a/code/include/rnd/item_override.h
+++ b/code/include/rnd/item_override.h
@@ -433,9 +433,16 @@ namespace rnd {
   void ItemOverride_CheckStartingItem();
   void ItemOverride_Init();
   void ItemOverride_Update();
+  extern "C" bool ItemOverride_CheckAromaGivenItem();
+  extern "C" bool ItemOverride_CheckMikauGivenItem();
+  extern "C" bool ItemOverride_CheckDarmaniGivenItem();
+  extern "C" void ItemOverride_GetItemTextAndItemID(game::act::Player*);
   extern "C" void ItemOverride_GetItem(game::GlobalContext*, game::act::Actor*, game::act::Player*, s16);
   extern "C" void ItemOverride_GetFairyRewardItem(game::GlobalContext*, game::act::GreatFairy*, s16);
-  extern "C" void ItemOverride_GetItemTextAndItemID(game::act::Player*);
+  extern "C" void ItemOverride_GetSoHItem(game::GlobalContext*, game::act::Actor*, s16);
+  extern "C" int ItemOverride_CheckInventoryItemOverride(game::ItemId);
+  extern "C" void ItemOverride_SwapSoHGetItemText(game::GlobalContext*, u16, game::act::Actor*);
+  extern "C" bool ItemOverride_CheckTingleMaps(u16, game::GlobalContext*);
   extern "C" u32 rActiveItemGraphicId;
   extern "C" ItemOverride rItemOverrides[640];
   extern "C" u16 rStoredBomberNoteTextId;

--- a/code/include/rnd/savefile.h
+++ b/code/include/rnd/savefile.h
@@ -52,7 +52,8 @@ namespace rnd {
       BitField<11, 1, u16> enOsnGivenNotebook;
       BitField<12, 1, u16> enFsnGivenItem;
       BitField<13, 1, u16> enPmGivenItem;
-      BitField<14, 2, u16> unused;
+      BitField<14, 2, u16> enSshGivenItem;
+      BitField<15, 1, u16> unused;
     };
     GivenItemRegister givenItemChecks;
     union FairyCollectRegister {

--- a/code/include/rnd/savefile.h
+++ b/code/include/rnd/savefile.h
@@ -7,7 +7,7 @@
 #include "z3d/z3DVec.h"
 
 // Increment the version number whenever the ExtSaveData structure is changed
-#define EXTSAVEDATA_VERSION 04
+#define EXTSAVEDATA_VERSION 05
 
 namespace rnd {
   void SaveFile_SkipMinorCutscenes();
@@ -51,7 +51,8 @@ namespace rnd {
       BitField<10, 1, u16> enOsnGivenMask;
       BitField<11, 1, u16> enOsnGivenNotebook;
       BitField<12, 1, u16> enFsnGivenItem;
-      BitField<13, 1, u16> unused;
+      BitField<13, 1, u16> enPmGivenItem;
+      BitField<14, 2, u16> unused;
     };
     GivenItemRegister givenItemChecks;
     union FairyCollectRegister {

--- a/code/include/rnd/savefile.h
+++ b/code/include/rnd/savefile.h
@@ -7,7 +7,7 @@
 #include "z3d/z3DVec.h"
 
 // Increment the version number whenever the ExtSaveData structure is changed
-#define EXTSAVEDATA_VERSION 05
+#define EXTSAVEDATA_VERSION 06
 
 namespace rnd {
   void SaveFile_SkipMinorCutscenes();
@@ -36,24 +36,25 @@ namespace rnd {
     u8 playedSosOnce;
     u8 playedElegyOnce;
     union GivenItemRegister {
-      u16 raw;
+      u32 raw;
 
-      BitField<0, 1, u16> enNbGivenItem;
-      BitField<1, 1, u16> enAlGivenItem;
-      BitField<2, 1, u16> enBabaGivenItem;
-      BitField<3, 1, u16> enStoneHeishiGivenItem;
-      BitField<4, 1, u16> mummyDaddyGivenItem;
-      BitField<5, 1, u16> enGuruGuruGivenItem;
-      BitField<6, 1, u16> enYbGivenItem;
-      BitField<7, 1, u16> enGegGivenItem;
-      BitField<8, 1, u16> enZogGivenItem;
-      BitField<9, 1, u16> enGgGivenItem;
-      BitField<10, 1, u16> enOsnGivenMask;
-      BitField<11, 1, u16> enOsnGivenNotebook;
-      BitField<12, 1, u16> enFsnGivenItem;
-      BitField<13, 1, u16> enPmGivenItem;
-      BitField<14, 2, u16> enSshGivenItem;
-      BitField<15, 1, u16> unused;
+      BitField<0, 1, u32> enNbGivenItem;
+      BitField<1, 1, u32> enAlGivenItem;
+      BitField<2, 1, u32> enBabaGivenItem;
+      BitField<3, 1, u32> enStoneHeishiGivenItem;
+      BitField<4, 1, u32> mummyDaddyGivenItem;
+      BitField<5, 1, u32> enGuruGuruGivenItem;
+      BitField<6, 1, u32> enYbGivenItem;
+      BitField<7, 1, u32> enGegGivenItem;
+      BitField<8, 1, u32> enZogGivenItem;
+      BitField<9, 1, u32> enGgGivenItem;
+      BitField<10, 1, u32> enOsnGivenMask;
+      BitField<11, 1, u32> enOsnGivenNotebook;
+      BitField<12, 1, u32> enFsnGivenItem;
+      BitField<13, 1, u32> enPmGivenItem;
+      BitField<14, 2, u32> enSshGivenItem;
+      BitField<15, 1, u32> enDnoGivenItem;
+      BitField<16, 16, u32> unused;
     };
     GivenItemRegister givenItemChecks;
     union FairyCollectRegister {

--- a/code/source/asm/tingle_patches.s
+++ b/code/source/asm/tingle_patches.s
@@ -35,3 +35,4 @@ patch_TingleCheckGreatBayMap:
 patch_TingleCheckStoneTowerMap:
     mov r0,#0x20
     bl hook_CheckTingle
+    beq 0x2DABA8

--- a/code/source/game/items.cpp
+++ b/code/source/game/items.cpp
@@ -113,9 +113,14 @@ namespace game {
 
   void GiveItem(ItemId item_id) {
     auto* gctx = rnd::GetContext().gctx;
-    auto& items = GetCommonData().save.inventory.items;
+    // auto& items = GetCommonData().save.inventory.items;
     rnd::util::GetPointer<int(game::GlobalContext*, game::ItemId)>(0x233BEC)(gctx, item_id);
-    items[(u32)item_id] = item_id;
+    rnd::util::GetPointer<void(game::ItemId)>(0x22B14C)(item_id);
+    // items[(u32)item_id] = item_id;
+  }
+
+  void PlaceItemInItemArray(ItemId item_id) {
+    //
   }
 
   void GiveMask(ItemId item_id) {

--- a/code/source/main.cpp
+++ b/code/source/main.cpp
@@ -58,21 +58,6 @@ namespace rnd {
 
     if (context.gctx->GetPlayerActor())
       ItemOverride_Update();
-
-#ifdef ENABLE_DEBUG
-    if (context.gctx->pad_state.input.buttons.IsSet(game::pad::Button::ZL)) {
-      game::act::Player* link = context.gctx->GetPlayerActor();
-      // Before calling let's be absolutely sure we have the player available.
-      if (link) {
-        // 007753CC <- watch point on this
-        game::SaveData& saveData = game::GetCommonData().save;
-        util::Print("%s: Address is %p and value is %u\n", __func__, &saveData.inventory.inventory_count_register,
-                    saveData.inventory.inventory_count_register);
-        return;
-      }
-    }
-#endif
-
     return;
   }
   void readPadInput() {

--- a/code/source/rnd/item_effect.cpp
+++ b/code/source/rnd/item_effect.cpp
@@ -186,22 +186,6 @@ namespace rnd {
     }*/
   }
 
-  void ItemEffect_PlaceMagicArrowsInInventory(game::CommonData* comData, s16 arg1, s16 arg2) {
-    if (arg1 == 0) {  // Fairy Bow
-      SaveFile_ResetItemSlotsIfMatchesID((u8)game::ItemId::FireArrow);
-      SaveFile_ResetItemSlotsIfMatchesID((u8)game::ItemId::IceArrow);
-      SaveFile_ResetItemSlotsIfMatchesID((u8)game::ItemId::LightArrow);
-    } else if (game::HasItem(game::ItemId::Arrow)) {
-      if (arg1 == 1 && !game::HasItem(game::ItemId::FireArrow)) {  // Fire Arrow
-        game::GiveItem(game::ItemId::FireArrow);
-      } else if (arg1 == 2 && !game::HasItem(game::ItemId::IceArrow)) {  // Ice Arrow
-        game::GiveItem(game::ItemId::IceArrow);
-      } else if (arg1 == 3 && !game::HasItem(game::ItemId::LightArrow)) {  // Light Arrow
-        game::GiveItem(game::ItemId::LightArrow);
-      }
-    }
-  }
-
   void ItemEffect_GiveUpgrade(game::CommonData* comData, s16 arg1, s16 arg2) {
     // This takes care of the item upgrade in inventory_count_register.
     util::GetPointer<void(u8, u8)>(0x023BF4C)(arg2, arg1);
@@ -266,12 +250,16 @@ namespace rnd {
     switch (mask) {
     case 0:
       comData->save.inventory.collect_register.odolwas_remains = 1;
+      break;
     case 1:
       comData->save.inventory.collect_register.gohts_remains = 1;
+      break;
     case 2:
       comData->save.inventory.collect_register.gyorgs_remains = 1;
+      break;
     case 3:
       comData->save.inventory.collect_register.twinmolds_remains = 1;
+      break;
     }
   }
 

--- a/code/source/rnd/item_override.cpp
+++ b/code/source/rnd/item_override.cpp
@@ -38,10 +38,10 @@ namespace rnd {
     rItemOverrides[0].key.type = ItemOverride_Type::OVR_COLLECTABLE;
     rItemOverrides[0].value.getItemId = 0x26;
     rItemOverrides[0].value.looksLikeItemId = 0x26;
-    rItemOverrides[1].key.scene = 0x6C;
+    rItemOverrides[1].key.scene = 0x1E;
     rItemOverrides[1].key.type = ItemOverride_Type::OVR_COLLECTABLE;
-    rItemOverrides[1].value.getItemId = 0x12;
-    rItemOverrides[1].value.looksLikeItemId = 0x12;
+    rItemOverrides[1].value.getItemId = 0x1E;
+    rItemOverrides[1].value.looksLikeItemId = 0x1E;
     rItemOverrides[2].key.scene = 0x12;
     rItemOverrides[2].key.type = ItemOverride_Type::OVR_COLLECTABLE;
     rItemOverrides[2].value.getItemId = 0x37;

--- a/code/source/rnd/item_override.cpp
+++ b/code/source/rnd/item_override.cpp
@@ -407,6 +407,8 @@ namespace rnd {
       getItemId = incomingNegative ? -0xBA : 0xBA;
     } else if (actorId == game::act::Id::EnSsh) {
       gExtSaveData.givenItemChecks.enSshGivenItem = 1;
+    } else if (actorId == game::act::Id::EnDno) {
+      gExtSaveData.givenItemChecks.enDnoGivenItem = 1;
     }
 #if defined ENABLE_DEBUG || defined DEBUG_PRINT
     rnd::util::Print("%s: Our get Item Id now now %#04x\n", __func__, getItemId);
@@ -600,6 +602,8 @@ namespace rnd {
     } else if (currentItem == game::ItemId::StoneMask && gExtSaveData.givenItemChecks.enStoneHeishiGivenItem == 0) {
       return (int)0xFF;
     } else if (currentItem == game::ItemId::MaskOfTruth && gExtSaveData.givenItemChecks.enSshGivenItem == 0) {
+      return (int)0xFF;
+    } else if (currentItem == game::ItemId::MaskOfScents && gExtSaveData.givenItemChecks.enDnoGivenItem == 0) {
       return (int)0xFF;
     }
 

--- a/code/source/rnd/item_override.cpp
+++ b/code/source/rnd/item_override.cpp
@@ -61,6 +61,10 @@ namespace rnd {
     game::CommonData& cdata = game::GetCommonData();
     ItemOverride_Key retKey;
     retKey.all = 0;
+    #if defined ENABLE_DEBUG || defined DEBUG_PRINT
+      rnd::util::Print("%s:Actor type is %#04x and ID is %#04x\n",\
+        __func__, (u16)actor->actor_type, actor->id);	
+    #endif
     if (actor->actor_type == game::act::Type::Chest) {
       // XXX: Any games like H&D or chest game to not swap?
       // Don't override WINNER purple rupee in the chest minigame scene
@@ -72,12 +76,7 @@ namespace rnd {
       // }
       retKey.scene = scene;
       retKey.type = ItemOverride_Type::OVR_CHEST;
-      // #if defined ENABLE_DEBUG || defined DEBUG_PRINT
-      //       util::Print("%s Our flag is actually %#06x and & 0x1F is %#06x\n", __func__,
-      //       actor->params, actor->params & 0x1F);
-      // #endif
       retKey.flag = actor->params & 0x1F;
-      return retKey;
     } else if (actor->actor_type == game::act::Type::Misc) {  // Heart pieces are misc apparently
       // Only override heart pieces and keys
       u32 collectibleType = actor->params & 0xFF;
@@ -88,23 +87,20 @@ namespace rnd {
       retKey.scene = scene;
       retKey.type = ItemOverride_Type::OVR_COLLECTABLE;
       retKey.flag = actor->overlay_info->info->flags;
-      return retKey;
     } else if (actor->id == (game::act::Id)game::ItemId::GoldSkulltula) {  // Gold Skulltula Token
       retKey.scene = (actor->params >> 8) & 0x1F;
       retKey.type = ItemOverride_Type::OVR_SKULL;
       retKey.flag = actor->params & 0xFF;
-      return retKey;
     } else if (scene == 0x14C0 && actor->id == (game::act::Id)0x0075) {  // Grotto Salesman
       retKey.scene = cdata.sub13s[8].data;
       retKey.type = ItemOverride_Type::OVR_GROTTO_SCRUB;
       retKey.flag = getItemId;
-      return retKey;
     } else {
       retKey.scene = scene;
       retKey.type = ItemOverride_Type::OVR_BASE_ITEM;
       retKey.flag = getItemId;
-      return retKey;
     }
+    return retKey;
   }
 
   ItemOverride ItemOverride_Lookup(game::act::Actor* actor, u16 scene, s16 getItemId) {
@@ -408,7 +404,12 @@ namespace rnd {
       gExtSaveData.givenItemChecks.enFsnGivenItem = 1;
     } else if (actorId == game::act::Id::NpcEnPm) {
       gExtSaveData.givenItemChecks.enPmGivenItem = 1;
+    } else if (actorId == game::act::Id::EnPst) {
+      getItemId = incomingNegative ? -0xBA : 0xBA;
     }
+    #if defined ENABLE_DEBUG || defined DEBUG_PRINT
+      rnd::util::Print("%s: Our get Item Id now now %#04x\n", __func__, getItemId);	
+    #endif
     return getItemId;
   }
 
@@ -475,7 +476,7 @@ namespace rnd {
       u8 itemId = rActiveItemRow->itemId;
       ItemTable_CallEffect(rActiveItemRow);
 #if defined ENABLE_DEBUG || defined DEBUG_PRINT
-      rnd::util::Print("%s:Player Item ID is %#04x\nScene is %#04x", __func__, actor->get_item_id, gctx->scene);
+      rnd::util::Print("%s:Player Item ID is %#04x\nScene is %#04x\n", __func__, actor->get_item_id, gctx->scene);
 #endif
       // if (gctx->scene != game::SceneId::GoronGraveyard && gctx->scene != game::SceneId::GreatBayCoast &&
       //     gctx->scene != game::SceneId::MusicBoxHouse && gctx->scene != game::SceneId::ClockTowerInterior)
@@ -611,6 +612,9 @@ namespace rnd {
   }
 
   bool ItemOverride_CheckTingleMaps(u16 mapId, game::GlobalContext* gctx) {
+    #if defined ENABLE_DEBUG || defined DEBUG_PRINT
+      rnd::util::Print("%s: Map id is %#04x\n", __func__, mapId);	
+    #endif
     switch (mapId) {
     case 0x1:
       if (gExtSaveData.tingleMaps.clock_town_map_get == 0) {

--- a/code/source/rnd/item_override.cpp
+++ b/code/source/rnd/item_override.cpp
@@ -406,6 +406,8 @@ namespace rnd {
       gExtSaveData.givenItemChecks.enBabaGivenItem = 1;
     } else if (actorId == game::act::Id::NpcEnFsn) {
       gExtSaveData.givenItemChecks.enFsnGivenItem = 1;
+    } else if (actorId == game::act::Id::NpcEnPm) {
+      gExtSaveData.givenItemChecks.enPmGivenItem = 1;
     }
     return getItemId;
   }
@@ -572,9 +574,9 @@ namespace rnd {
     return;
   }
 
-  void ItemOverride_RemoveTextId() {
+  /*void ItemOverride_RemoveTextId() {
     rStoredBomberNoteTextId = 0;
-  }
+  }*/
 
   int ItemOverride_CheckInventoryItemOverride(game::ItemId currentItem) {
     if (currentItem == game::ItemId::BlastMask && gExtSaveData.givenItemChecks.enBabaGivenItem == 0) {
@@ -590,6 +592,8 @@ namespace rnd {
     } else if (currentItem == game::ItemId::LetterToMama && gExtSaveData.givenItemChecks.enBabaGivenItem == 0) {
       return (int)0xFF;
     } else if (currentItem == game::ItemId::KeatonMask && gExtSaveData.givenItemChecks.enFsnGivenItem == 0) {
+      return (int)0xFF;
+    } else if (currentItem == game::ItemId::PostmanHat && gExtSaveData.givenItemChecks.enPmGivenItem == 0) {
       return (int)0xFF;
     }
 
@@ -646,12 +650,6 @@ namespace rnd {
       return false;
     }
     return false;
-  }
-
-  u16 ItemOverride_CheckKeatonExt() {
-    if (gExtSaveData.givenItemChecks.enFsnGivenItem == 0) {
-      return 0xFF;
-    }
   }
   }
 }  // namespace rnd

--- a/code/source/rnd/item_override.cpp
+++ b/code/source/rnd/item_override.cpp
@@ -61,10 +61,9 @@ namespace rnd {
     game::CommonData& cdata = game::GetCommonData();
     ItemOverride_Key retKey;
     retKey.all = 0;
-    #if defined ENABLE_DEBUG || defined DEBUG_PRINT
-      rnd::util::Print("%s:Actor type is %#04x and ID is %#04x\n",\
-        __func__, (u16)actor->actor_type, actor->id);	
-    #endif
+#if defined ENABLE_DEBUG || defined DEBUG_PRINT
+    rnd::util::Print("%s:Actor type is %#04x and ID is %#04x\n", __func__, (u16)actor->actor_type, actor->id);
+#endif
     if (actor->actor_type == game::act::Type::Chest) {
       // XXX: Any games like H&D or chest game to not swap?
       // Don't override WINNER purple rupee in the chest minigame scene
@@ -407,9 +406,9 @@ namespace rnd {
     } else if (actorId == game::act::Id::EnPst) {
       getItemId = incomingNegative ? -0xBA : 0xBA;
     }
-    #if defined ENABLE_DEBUG || defined DEBUG_PRINT
-      rnd::util::Print("%s: Our get Item Id now now %#04x\n", __func__, getItemId);	
-    #endif
+#if defined ENABLE_DEBUG || defined DEBUG_PRINT
+    rnd::util::Print("%s: Our get Item Id now now %#04x\n", __func__, getItemId);
+#endif
     return getItemId;
   }
 
@@ -612,9 +611,6 @@ namespace rnd {
   }
 
   bool ItemOverride_CheckTingleMaps(u16 mapId, game::GlobalContext* gctx) {
-    #if defined ENABLE_DEBUG || defined DEBUG_PRINT
-      rnd::util::Print("%s: Map id is %#04x\n", __func__, mapId);	
-    #endif
     switch (mapId) {
     case 0x1:
       if (gExtSaveData.tingleMaps.clock_town_map_get == 0) {

--- a/code/source/rnd/item_override.cpp
+++ b/code/source/rnd/item_override.cpp
@@ -595,6 +595,8 @@ namespace rnd {
       return (int)0xFF;
     } else if (currentItem == game::ItemId::PostmanHat && gExtSaveData.givenItemChecks.enPmGivenItem == 0) {
       return (int)0xFF;
+    } else if (currentItem == game::ItemId::StoneMask && gExtSaveData.givenItemChecks.enStoneHeishiGivenItem == 0) {
+      return (int)0xFF;
     }
 
     return (int)currentItem;

--- a/code/source/rnd/item_override.cpp
+++ b/code/source/rnd/item_override.cpp
@@ -405,6 +405,8 @@ namespace rnd {
       gExtSaveData.givenItemChecks.enPmGivenItem = 1;
     } else if (actorId == game::act::Id::EnPst) {
       getItemId = incomingNegative ? -0xBA : 0xBA;
+    } else if (actorId == game::act::Id::EnSsh) {
+      gExtSaveData.givenItemChecks.enSshGivenItem = 1;
     }
 #if defined ENABLE_DEBUG || defined DEBUG_PRINT
     rnd::util::Print("%s: Our get Item Id now now %#04x\n", __func__, getItemId);
@@ -596,6 +598,8 @@ namespace rnd {
     } else if (currentItem == game::ItemId::PostmanHat && gExtSaveData.givenItemChecks.enPmGivenItem == 0) {
       return (int)0xFF;
     } else if (currentItem == game::ItemId::StoneMask && gExtSaveData.givenItemChecks.enStoneHeishiGivenItem == 0) {
+      return (int)0xFF;
+    } else if (currentItem == game::ItemId::MaskOfTruth && gExtSaveData.givenItemChecks.enSshGivenItem == 0) {
       return (int)0xFF;
     }
 

--- a/code/source/rnd/item_table.cpp
+++ b/code/source/rnd/item_table.cpp
@@ -205,7 +205,7 @@ namespace rnd {
 
       [0x22] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::Arrow, 0x0022, 0x00BF,
                         (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_HERO_BOW_AND_ARROW,
-                        (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_PlaceMagicArrowsInInventory, (s16)0,
+                        (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)0,
                         (s16)-1),  // Hero's Bow
 
       [0x23] =
@@ -221,16 +221,16 @@ namespace rnd {
 
       [0x25] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::FireArrow, 0x0025, 0x00121,
                         (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_FIRE_ARROW,
-                        (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_GiveUpgrade, (s16)3, (s16)0),  // Fire Arrow
+                        (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)3, (s16)0),  // Fire Arrow
 
       [0x26] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::IceArrow, 0x0026, 0x00121,
-                        (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_ICE_ARROW,
-                        (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_GiveUpgrade, (s16)3, (s16)0),  // Ice Arrow
+                        (s8)0x01, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_ICE_ARROW,
+                        (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)3, (s16)0),  // Ice Arrow
 
       [0x27] =
           ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::LightArrow, 0x0027, 0x00121,
-                   (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_LIGHT_ARROW,
-                   (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_GiveUpgrade, (s16)3, (s16)0),  // Light Arrow
+                   (s8)0x02, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_LIGHT_ARROW,
+                   (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)3, (s16)0),  // Light Arrow
 
       [0x28] = ITEM_ROW((u32)GetItemID::GI_RUPEE_BLUE, ChestType::WOODEN_SMALL, (u8)game::ItemId::DekuNuts, 0x0028,
                         0x0094, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_DEKU_NUT,

--- a/code/source/rnd/item_upgrade.cpp
+++ b/code/source/rnd/item_upgrade.cpp
@@ -76,14 +76,14 @@ namespace rnd {
 
   GetItemID ItemUpgrade_ArrowsToRupee(game::SaveData* saveCtx, GetItemID getItemId) {
     return (saveCtx->inventory.inventory_count_register.quiver_upgrade == game::Quiver::NoQuiver) ?
-               getItemId :
-               GetItemID::GI_RUPEE_BLUE;  // Blue Rupee
+               GetItemID::GI_RUPEE_BLUE :  // Blue Rupee
+               getItemId;
   }
 
   GetItemID ItemUpgrade_BombsToRupee(game::SaveData* saveCtx, GetItemID getItemId) {
     return (saveCtx->inventory.inventory_count_register.bomb_bag_upgrade == game::BombBag::NoBag) ?
-               getItemId :
-               GetItemID::GI_RUPEE_BLUE;  // Blue Rupee
+               GetItemID::GI_RUPEE_BLUE :  // Blue Rupee
+               getItemId;
   }
 
   // TODO: Trade quest items.

--- a/code/source/rnd/ocarina.cpp
+++ b/code/source/rnd/ocarina.cpp
@@ -63,7 +63,7 @@ namespace rnd {
       played_once = (bool)gExtSaveData.playedSosOnce;
       if (!played_once) {
         gExtSaveData.playedSosOnce = 1;
-        util::Print("\n%s: Returning false.\n", __func__);
+        util::Print("%s: Returning false.\n", __func__);
         return false;
       }
 

--- a/code/source/rnd/savefile.cpp
+++ b/code/source/rnd/savefile.cpp
@@ -24,16 +24,16 @@ namespace rnd {
     saveData.equipment.sword_shield.sword = game::SwordType::GildedSword;
     saveData.equipment.sword_shield.shield = game::ShieldType::MirrorShield;
     saveData.player.razor_sword_hp = 0x64;
-    saveData.inventory.inventory_count_register.quiver_upgrade = game::Quiver::Quiver50;
+    // saveData.inventory.inventory_count_register.quiver_upgrade = game::Quiver::Quiver50;
     saveData.inventory.inventory_count_register.bomb_bag_upgrade = game::BombBag::BombBag40;
     // saveData.inventory.inventory_count_register.wallet_upgrade = 2;
     saveData.inventory.inventory_count_register.stick_upgrades = 2;
     saveData.inventory.inventory_count_register.nut_upgrade = 2;
     saveData.player.rupee_count = 500;
-    saveData.inventory.items[1] = game::ItemId::Arrow;
-    saveData.inventory.items[2] = game::ItemId::FireArrow;
-    saveData.inventory.items[3] = game::ItemId::IceArrow;
-    saveData.inventory.items[4] = game::ItemId::LightArrow;
+    // saveData.inventory.items[1] = game::ItemId::Arrow;
+    // saveData.inventory.items[2] = game::ItemId::FireArrow;
+    // saveData.inventory.items[3] = game::ItemId::IceArrow;
+    // saveData.inventory.items[4] = game::ItemId::LightArrow;
     saveData.inventory.items[6] = game::ItemId::Bomb;
     saveData.inventory.items[7] = game::ItemId::Bombchu;
     saveData.inventory.items[8] = game::ItemId::DekuStick;
@@ -436,7 +436,8 @@ namespace rnd {
     } else {
       saveData.inventory.inventory_count_register.quiver_upgrade = game::Quiver::NoQuiver;
 #if defined ENABLE_DEBUG || defined DEBUG_PRINT
-      saveData.inventory.inventory_count_register.quiver_upgrade = game::Quiver::Quiver50;
+      saveData.inventory.inventory_count_register.quiver_upgrade = game::Quiver::NoQuiver;
+      // rnd::util::GetPointer<void(game::ItemId, int)>(0x21d440)(game::ItemId::Arrow, 0x1e);
 #endif
     }
 

--- a/code/source/rnd/savefile.cpp
+++ b/code/source/rnd/savefile.cpp
@@ -24,6 +24,8 @@ namespace rnd {
     saveData.equipment.sword_shield.sword = game::SwordType::GildedSword;
     saveData.equipment.sword_shield.shield = game::ShieldType::MirrorShield;
     saveData.player.razor_sword_hp = 0x64;
+    saveData.skulltulas_collected.swamp_count = 30;
+    rnd::util::GetPointer<void(game::ItemId)>(0x22b14c)(game::ItemId::MaskOfTruth);
     // saveData.inventory.inventory_count_register.quiver_upgrade = game::Quiver::Quiver50;
     saveData.inventory.inventory_count_register.bomb_bag_upgrade = game::BombBag::BombBag40;
     // saveData.inventory.inventory_count_register.wallet_upgrade = 2;


### PR DESCRIPTION
A few checks for masks that were intended to be extdata checks.

- Postman's Hate
- Stone Mask
- Mask of scents
- Mask of Truth

Also included were fixes to arrows giving the largest quiver possible.

Tingle now will give stone tower temple map instead of blocking you out saying you already have it.

Cleaned up some bad code with the item override returns.

Postboxes now give fishing passes as default to avoid same base item interactions with heart pieces in ECT and NCT.