### PR TITLE
Update settings.h

### DIFF
--- a/code/include/rnd/settings.h
+++ b/code/include/rnd/settings.h
@@ -201,16 +201,16 @@ namespace rnd {
   };
 
   enum class StartingSwordSetting : u8 {
-    STARTINGSWORD_NONE,
     STARTINGSWORD_KOKIRI,
     STARTINGSWORD_RAZOR,
     STARTINGSWORD_GILDED,
+    STARTINGSWORD_NONE,
   };
 
   enum class StartingSheildSetting : u8 {
-    STARTINGSHIELD_NONE,
     STARTINGSHIELD_HERO,
     STARTINGSHIELD_MIRROR,
+    STARTINGSHIELD_NONE,
   };
 
   enum class StartingSpinSetting : u8 {


### PR DESCRIPTION
Swaps the NONE settings for StartingSwordSetting and StartingShieldSetting to make the default options STARTINGSWORD_KOKIRI, and STARTINGSHIELD_HEROS, instead of STARTINGSWORD_NONE, and STARTINGSHIELD_NONE,
Shouldn't be necessary but the App refuses to set the default value to anything other than default(0) regardless of how many ways its told to use a different value. 