### PR TITLE
Gossip stone hints

### DIFF
--- a/code/include/game/common_data.h
+++ b/code/include/game/common_data.h
@@ -455,7 +455,7 @@ namespace game {
     char anonymous_122;
     u8 anju_0x10_if_obtained_small_key;
     char anonymous_124;
-    char anonymous_125;
+    char grotto_stones_bitflag;
     char anonymous_126;
     u8 removes_scarecrow_from_shop_0x08;
     char anonymous_128;  // Possibly more Cutscene flags
@@ -478,7 +478,7 @@ namespace game {
     TatlDialogueFlags tatl_dialogue_direction_to_go;
     u8 mikau_pushed_to_shore_0x10;
     char anonymous_137;
-    char anonymous_138;
+    char gossip_stone_give_heartpiece_bitflag;
     u8 mikau_dialogue_flags_0x03;
     char anonymous_140;
     char anonymous_141;

--- a/code/include/game/items.h
+++ b/code/include/game/items.h
@@ -277,6 +277,8 @@ namespace game {
 
   // Mask IDs are action IDs - 0x3b
   enum class MaskId : u8 {
+    MaskOfTruth = 0x01,
+    BunnyHood = 0x04,
     BlastMask = 0x12,
     GiantMask = 0x14,
     FierceDeityMask = 0x15,

--- a/code/include/game/player.h
+++ b/code/include/game/player.h
@@ -416,7 +416,7 @@ namespace game::act {
     u8 gap_11EC0[6];
     char field_11EC6;
     char field_11EC7;
-    u16 field_11EC8;
+    u16 disable_b_if_255;
     u16 zora_barrier_timer;
     u16 field_11ECC;
     char field_11ECE[1];

--- a/code/include/rnd/settings.h
+++ b/code/include/rnd/settings.h
@@ -395,6 +395,8 @@ namespace rnd {
     u8 enableFastZoraSwim = 1;
     u8 enableOcarinaDiving = 1;
     u8 enableFastElegyStatues = 0;
+    u8 maskOfTruthRequiredForGossip = 0;
+
     // Custom Buttons
     u32 customMapButton = 0;
     u32 customItemButton = 0;

--- a/code/include/rnd/settings.h
+++ b/code/include/rnd/settings.h
@@ -332,8 +332,6 @@ namespace rnd {
     u8 startingBottle7;
 
     u8 startingKokiriSword;
-    u8 startingRazorSword;
-    u8 startingGildedSword;
     u8 startingShield;
     u8 startingMagicMeter;
     u8 startingDoubleDefense;

--- a/code/mm.ld
+++ b/code/mm.ld
@@ -159,6 +159,14 @@ SECTIONS{
     *(.patch_FasterBlockMovement)
   }
 
+  .patch_DoNotRemoveSwordGaboraOne 0x2CBCB0 : {
+    *(.patch_DoNotRemoveSwordGabora)
+  }
+
+  .patch_DoNotRemoveSwordGaboraTwo 0x2CBCC0 : {
+    *(.patch_DoNotRemoveSwordGabora)
+  }
+
   .patch_FasterBlockMovementBack 0x2D0C0C : {
     *(.patch_FasterBlockMovementBack)
   }

--- a/code/mm.ld
+++ b/code/mm.ld
@@ -211,6 +211,10 @@ SECTIONS{
     *(.patch_AromaItemCheck)
   }
 
+  .patch_CheckMoTRequirement 0x35C428 : {
+    *(.patch_CheckMoTRequirement)
+  }
+
   .patch_HMSGiveItem 0x41D018 : {
     *(.patch_HMSGiveItem)
   }

--- a/code/source/asm/hooks.s
+++ b/code/source/asm/hooks.s
@@ -252,6 +252,11 @@ hook_AromaItemCheck:
     pop {r0-r12, lr}
     b 0x350920
 
+.global hook_CheckMoTSetting
+hook_CheckMoTSetting:
+    bl SettingsMaskOfTruthCheck
+    b 0x35C42C
+
 .global hook_GoronMaskGiveItem
 hook_GoronMaskGiveItem:
     push {r0-r12, lr}

--- a/code/source/asm/patches.s
+++ b/code/source/asm/patches.s
@@ -238,6 +238,12 @@ patch_TwinmoldConsistentDamage:
 patch_FasterBlockMovement:
     .float 50.0
 
+@ Removes sword being removed from inventory during 
+.section .patch_DoNotRemoveSwordGabora
+.global patch_DoNotRemoveSwordGabora
+patch_DoNotRemoveSwordGabora:
+    nop
+
 .section .patch_FasterBlockMovementBack
 .global patch_FasterBlockMovementBack
 patch_FasterBlockMovementBack:

--- a/code/source/asm/patches.s
+++ b/code/source/asm/patches.s
@@ -258,6 +258,11 @@ patch_RemoveZoraMaskCheckMikau:
 patch_AromaItemCheck:
     b hook_AromaItemCheck
 
+.section .patch_CheckMoTRequirement
+.global patch_CheckMoTRequirement
+patch_CheckMoTRequirement:
+    b hook_CheckMoTSetting
+
 .section .patch_HMSGiveItem
 .global patch_HMSGiveItem
 patch_HMSGiveItem:

--- a/code/source/game/items.cpp
+++ b/code/source/game/items.cpp
@@ -811,7 +811,7 @@ namespace game {
     if (cdata.save.anonymous_13 & 2)
       return false;
 
-    if (cdata.save.anonymous_138 & 0x20)
+    if (cdata.save.gossip_stone_give_heartpiece_bitflag & 0x20)
       return false;
 
     if (cdata.save.anonymous_130 & 8)

--- a/code/source/main.cpp
+++ b/code/source/main.cpp
@@ -6,7 +6,6 @@
 #include "game/sound.h"
 #include "game/states/state.h"
 #include "game/ui.h"
-#include "rnd/custom_message.h"
 #include "rnd/extdata.h"
 #include "rnd/icetrap.h"
 #include "rnd/item_override.h"
@@ -29,7 +28,6 @@ namespace rnd {
 
     rHeap_Init();
     ItemOverride_Init();
-    CustomMessage_Init();
     // SaveFile_LoadExtSaveData(1);
     //  TODO: Maybe make this an option?
     link::FixSpeedIssues();

--- a/code/source/rnd/custom_messages.cpp
+++ b/code/source/rnd/custom_messages.cpp
@@ -377,7 +377,7 @@ bool SetCustomMessage(u16 id, game::MessageResEntry* msgResEntry) {
 #if defined ENABLE_DEBUG || defined DEBUG_PRINT
   static u16 lastId;
   if (id && id != lastId)
-    rnd::util::Print("Message ID is %x\n", id);
+    rnd::util::Print("Message ID is %#06x\n", id);
   lastId = id;
 
   if (!declareTestMessage) {

--- a/code/source/rnd/settings.cpp
+++ b/code/source/rnd/settings.cpp
@@ -92,6 +92,25 @@ namespace rnd {
   u8 SettingsEnableFastElegy(void) {
     return gSettingsContext.enableFastElegyStatues;
   }
+
+  u8 SettingsMaskOfTruthCheck(game::GlobalContext* gctx) {
+#if defined ENABLE_DEBUG || defined DEBUG_PRINT
+      rnd::util::Print("%s: Checking mask of truth setting.\n", __func__);	
+#endif
+    if (gSettingsContext.maskOfTruthRequiredForGossip == 1) {
+      #if defined ENABLE_DEBUG || defined DEBUG_PRINT
+        rnd::util::Print("%s: Active mask is %#04x\n", __func__, gctx->GetPlayerActor()->active_mask_id);	
+      #endif
+      if (gctx->GetPlayerActor()->active_mask_id == game::MaskId::MaskOfTruth) {
+        return 1;
+      } else {
+        return 0;
+      }
+    } else {
+      return 1;
+    }
+    return 0;
+  }
   }
   // TODO: Change the addr
   /* typedef void (*Health_ChangeBy_proc)(GlobalContext *arg1, u32 arg2);

--- a/code/source/rnd/settings.cpp
+++ b/code/source/rnd/settings.cpp
@@ -94,13 +94,7 @@ namespace rnd {
   }
 
   u8 SettingsMaskOfTruthCheck(game::GlobalContext* gctx) {
-#if defined ENABLE_DEBUG || defined DEBUG_PRINT
-      rnd::util::Print("%s: Checking mask of truth setting.\n", __func__);	
-#endif
     if (gSettingsContext.maskOfTruthRequiredForGossip == 1) {
-      #if defined ENABLE_DEBUG || defined DEBUG_PRINT
-        rnd::util::Print("%s: Active mask is %#04x\n", __func__, gctx->GetPlayerActor()->active_mask_id);	
-      #endif
       if (gctx->GetPlayerActor()->active_mask_id == game::MaskId::MaskOfTruth) {
         return 1;
       } else {


### PR DESCRIPTION
This update now adds a setting for checking for Mask Of Truth when talking to stones. This should allow a patch to now fully override with hints. This merge also fixes Gabora and Zubora taking away your sword when giving them money.