### PR TITLE
More Cutscene Adjustments

### DIFF
--- a/code/include/rnd/custom_entrances.h
+++ b/code/include/rnd/custom_entrances.h
@@ -1,0 +1,20 @@
+#ifndef _RND_CUSTOM_MESSAGES_H_
+#define _RND_CUSTOM_MESSAGES_H_
+
+#include "common/advanced_context.h"
+#include "game/common_data.h"
+#include "game/sound.h"
+#include "rnd/settings.h"
+
+#if defined ENABLE_DEBUG || defined DEBUG_PRINT
+#include "common/debug.h"
+extern "C" {
+#include <3ds/svc.h>
+}
+#endif
+
+namespace rnd {
+  extern "C" bool SceneEntranceOverride();
+} // namespace rnd
+
+#endif

--- a/code/include/rnd/settings.h
+++ b/code/include/rnd/settings.h
@@ -389,7 +389,7 @@ namespace rnd {
     u32 startingUpgrades;
     game::PlayerData::OwlStatues startingOwlStatues;
 
-    // ARM Patch Checks
+    // ARM Patch Checks / Restoration Checks
     u8 enableFastZoraSwim;
     u8 enableOcarinaDiving;
     u8 enableFastElegyStatues;
@@ -397,6 +397,12 @@ namespace rnd {
     u8 enableFastMaskTransform;
     u8 enableFastOcarina;
     u8 enableFastArrowSwap;
+
+
+    // Cutscene Skips
+    u8 skipHMSCutscenes;
+    u8 skipMikauCutscene;
+
 
     // Custom Buttons
     u32 customMapButton = 0;

--- a/code/mm.ld
+++ b/code/mm.ld
@@ -39,6 +39,10 @@ SECTIONS{
     *(.patch_RemoveMeetMaskCutScene)
   } */
 
+  .patch_OverrideCutsceneNextEntrance 0x1B1834 : {
+    *(.patch_OverrideCutsceneNextEntrance)
+  }
+
   .patch_RemoveMysteryMilkTimer 0x1B7A54 : {
     *(.patch_RemoveMysteryMilkTimer)
   }

--- a/code/source/asm/hooks.s
+++ b/code/source/asm/hooks.s
@@ -32,6 +32,18 @@ hook_MainLoop:
     ldr r1, [r0,#0x138]
     b 0x0106770
 
+.global hook_OverrideCutsceneNextEntrance
+hook_OverrideCutsceneNextEntrance:
+    push {r0-r12, lr}
+    bl SceneEntranceOverride
+    cmp r0,#0x1
+    pop {r0-r12, lr}
+    bne doNotOverrideCutscene
+    bx lr
+doNotOverrideCutscene:
+    bl 0x22A7F8
+    b 0x1B1838
+
 .global hook_ChangeSOHToCustomText
 hook_ChangeSOHToCustomText:
     push {r0-r2, lr}

--- a/code/source/asm/patches.s
+++ b/code/source/asm/patches.s
@@ -52,6 +52,11 @@ patch_RemoveSOHCutesceneAfterMessage:
 patch_OverrideBombersNotebook:
     b hook_OverrideHMSBombers
 
+.section .patch_OverrideCutsceneNextEntrance
+.global patch_OverrideCutsceneNextEntrance
+patch_OverrideCutsceneNextEntrance:
+    bl hook_OverrideCutsceneNextEntrance
+
 @ There's a while loop located in the event
 @ timer that checks if we have mystery milk.
 @ We do not wish to show this since we want to remove

--- a/code/source/main.cpp
+++ b/code/source/main.cpp
@@ -45,7 +45,9 @@ namespace rnd {
   char* fake_heap_end;
   extern void (*__init_array_start[])(void) __attribute__((weak));
   extern void (*__init_array_end[])(void) __attribute__((weak));
-
+#if defined ENABLE_DEBUG || defined DEBUG_PRINT
+  static bool titlePlayed = false;
+#endif
   void calc(game::State* state) {
     Context& context = GetContext();
     context.gctx = nullptr;
@@ -54,8 +56,24 @@ namespace rnd {
       Init(context);
     }
 
+#if defined ENABLE_DEBUG || defined DEBUG_PRINT
+    if (state->type == game::StateType::FileSelect) {
+      if (!titlePlayed) {
+        game::sound::ControlStream(game::sound::StreamPlayer::DEFAULT_PLAYER, 1, 1);
+        game::sound::PlayStream(game::sound::StreamId::NA_BGM_MUJURA_2, game::sound::StreamPlayer::DEFAULT_PLAYER);
+        titlePlayed = true;
+      }
+       
+        return;
+      }
+      else if (state->type != game::StateType::Play)
+        return;
+#else
     if (state->type != game::StateType::Play)
-      return;
+        return;
+#endif
+    
+    
     context.gctx = static_cast<game::GlobalContext*>(state);
 
     if (context.gctx->GetPlayerActor()) {

--- a/code/source/rnd/custom_entrances.cpp
+++ b/code/source/rnd/custom_entrances.cpp
@@ -1,0 +1,35 @@
+#include "rnd/custom_entrances.h"
+
+namespace rnd {
+  extern "C" bool SceneEntranceOverride() {
+    game::CommonData& cdata = game::GetCommonData();
+    game::GlobalContext* gctx = GetContext().gctx;
+    bool didWarp = false;
+    #if defined ENABLE_DEBUG || defined DEBUG_PRINT
+      rnd::util::Print("%s: Our next entrance is %#08x\n", __func__, gctx->next_entrance);	
+    #endif
+    if (gctx->next_entrance == 0x1C04 && gSettingsContext.skipMikauCutscene) {
+      gctx->next_entrance = 0x6890;
+      cdata.sub13s[0].entrance_index = 0x6890;
+      didWarp = true;
+    } else if (gctx->next_entrance == 0x1c19 && gSettingsContext.skipHMSCutscenes) {
+      gctx->next_entrance = 0xc060;
+      cdata.sub13s[0].entrance_index = 0xc060;
+      didWarp = true;
+      // Re-enable the sound track.
+      game::sound::ControlStream(game::sound::StreamPlayer::DEFAULT_PLAYER, 1, 1);
+      game::sound::PlayStream(game::sound::StreamId::NA_BGM_CLOCK_TOWER, game::sound::StreamPlayer::DEFAULT_PLAYER);
+    } else if (gctx->next_entrance == 0x1C01 && gSettingsContext.skipHMSCutscenes) {
+      gctx->next_entrance = 0xC020;
+      cdata.sub13s[0].entrance_index = 0xC020;
+      didWarp = true;
+      // Re-enable the sound track.
+      game::sound::ControlStream(game::sound::StreamPlayer::DEFAULT_PLAYER, 1, 1);
+      game::sound::PlayStream(game::sound::StreamId::NA_BGM_CLOCK_TOWER, game::sound::StreamPlayer::DEFAULT_PLAYER);
+    }
+
+    if (didWarp)
+      gctx->field_C529_one_to_clear_input = 0x14;
+    return didWarp;
+  }
+}

--- a/code/source/rnd/item_override.cpp
+++ b/code/source/rnd/item_override.cpp
@@ -610,11 +610,6 @@ namespace rnd {
     } else if (textId == 0x85) {
       gctx->ShowMessage(rStoredTextId);
       rStoredTextId = 0;
-    } else if (textId == 0x1FBC) {
-      game::CommonData& cdata = game::GetCommonData();
-      gctx->next_entrance = 0xc060;
-      cdata.sub13s[0].entrance_index = 0xc060;
-      gctx->field_C529_one_to_clear_input = 0x14;
     } else
       gctx->ShowMessage(textId);
     return;


### PR DESCRIPTION
This should allow us to expand on cutscene skips now by breaking out into a custom function.

If we don't return true then we just play normally, which should not break any cutscenes that we just leave. Now includes new options to either disable or enable these cutscenes in settings.h