### PR TITLE
Fix Banker & Archery Overrides

### DIFF
--- a/code/include/game/actor.h
+++ b/code/include/game/actor.h
@@ -26,35 +26,37 @@ namespace game::act {
 
   enum class Id : u16 {
     // [2] Player actor
-    Player = 0,
+    Player = 0x0000,
     // Arrow
-    Arrow = 0xf,
+    Arrow = 0x000F,
     // DayTimer
-    DayTimer = 0xf5,
+    DayTimer = 0x00F5,
     // Elegy of Emptiness statue
-    ObjElegyStatue = 0x1F,
+    ObjElegyStatue = 0x001F,
     // En_Gm - Gorman Bros Race
-    EnIn = 0x4D,
+    EnIn = 0x004D,
     // Clear Tag (?)
-    ClearTag = 0x73,
+    ClearTag = 0x0073,
     // En_Hs - Grog The Chicken Man
-    EnHs = 0x76,
+    EnHs = 0x0076,
     // Cursed Man Spider House
-    EnSsh = 0x90,
+    EnSsh = 0x0090,
     // [1] Deku Palace / Woodfall Temple moving platforms (after player lands on them)
-    ObjRailLift = 0xd8,
+    ObjRailLift = 0x00D8,
     // Shooting Gallery - Man
-    EnSyatekiMan = 0xC2,
+    EnSyatekiMan = 0x00C2,
     // [9] Odolwa
-    BossOdolwa = 0xcb,
+    BossOdolwa = 0x00CB,
     // [9] Twinmold (Red/Blue)
-    BossTwinmold = 0xcc,
+    BossTwinmold = 0x00CC,
     // [9] Gyorg
-    BossGyorg = 0xcd,
+    BossGyorg = 0x00CD,
     // Great Fairy
-    NpcGreatFairy = 0xD2,
+    NpcGreatFairy = 0x00D2,
     // [4] Kafei
     NpcKafei = 0x00F4,
+    // Banker
+    EnGinkoMan = 0x010F,
     // Deku Butler
     EnDno = 0x0117,
     // Ice platform created using ice arrows.
@@ -69,6 +71,8 @@ namespace game::act {
     BossGoht = 0x016E,
     // Postbox
     EnPst = 0x0182,
+    // Ocean Spiderhouse NPC
+    EnOsh = 0x019A,
     // Cremia
     EnMaYto = 0x01AF,
     // [7] Owl statue
@@ -80,15 +84,15 @@ namespace game::act {
     // GuruGuru (Bremen Mask Give Item)
     NpcEnGuruGuru = 0x01D7,
     // Npc Invisible Guard
-    NpcInvisibleGuard = 0x1D9,
+    NpcInvisibleGuard = 0x01D9,
     // Pamela's Father Gibdo Mode
-    EnHgo = 0x1DF,
+    EnHgo = 0x01DF,
     // Deku Salesmen
     EnDns = 0x01DB,
     // Npc Madame Aroma
-    NpcAroma = 0x1F1,
+    NpcAroma = 0x01F1,
     // Npc Mayor Dotour
-    EnDt = 0x1FE,
+    EnDt = 0x01FE,
     // [4] Rosa Sisters
     NpcRosaSisters = 0x020A,
     // En_Yb (Kamarao)

--- a/code/mm.ld
+++ b/code/mm.ld
@@ -239,6 +239,14 @@ SECTIONS{
     *(.patch_RemoveGoronMaskCheckDarmani)
   }
 
+  .patch_OverrideQuiverArcheryTown 0x3E50E4 : {
+    *(.patch_OverrideQuiverArchery)
+  }
+
+  .patch_OverrideQuiverArcherySwamp 0x3EA2B0 : {
+    *(.patch_OverrideQuiverArchery)
+  }
+
   .patch_OverrideFairyGiveItem 0x3BECAC : {
     *(.patch_OverrideFairyGiveItem)
   }
@@ -261,6 +269,10 @@ SECTIONS{
 
   .patch_AromaItemCheck 0x35091C : {
     *(.patch_AromaItemCheck)
+  }
+
+  .patch_OverrideWalletSpiderHouse 0x3E50B4 : {
+    *(.patch_OverrideWalletSpiderHouse)
   }
 
   .patch_CheckMoTRequirement 0x35C428 : {
@@ -289,6 +301,10 @@ SECTIONS{
   /*0x46E228*/
   .patch_RemoveCouplesMaskMessage 0x1867C4 : {
     *(.patch_RemoveCouplesMaskMessage)
+  }
+
+  .patch_OverrideBankerWalletReward 0x459044 : {
+    *(.patch_OverrideBankerWalletReward)
   }
 
   .patch_CouplesMaskGiveItem 0x46E228 : {

--- a/code/source/asm/hooks.s
+++ b/code/source/asm/hooks.s
@@ -264,6 +264,14 @@ hook_AromaItemCheck:
     pop {r0-r12, lr}
     b 0x350920
 
+.global hook_OverrideWalletCheckSpiderHouse
+hook_OverrideWalletCheckSpiderHouse:
+    push {r0-r12, lr}
+    bl ItemOverride_CheckBankerExtData
+    pop {r0-r12, lr}
+    cmp r0,#0x2
+    bx lr
+
 .global hook_CheckMoTSetting
 hook_CheckMoTSetting:
     bl SettingsMaskOfTruthCheck
@@ -379,7 +387,6 @@ hook_AdjustCouplesMaskMessage:
 normalText:
     mov r1,#0xA2
     b 0x1867C8
-
 
 .section .loader
 .global hook_into_loader

--- a/code/source/asm/patches.s
+++ b/code/source/asm/patches.s
@@ -197,6 +197,11 @@ OverrideItemID_patch:
 patch_RemoveGoronMaskCheckDarmani:
     b hook_DarmaniRewardCheck
 
+.section .patch_OverrideQuiverArchery
+.global patch_OverrideQuiverArchery
+patch_OverrideQuiverArchery:
+    mov r2,#0x47
+
 .section .patch_OverrideFairyGiveItem
 .global OverrideFairyItemID_patch
 OverrideFairyItemID_patch:
@@ -275,6 +280,12 @@ patch_RemoveZoraMaskCheckMikau:
 patch_AromaItemCheck:
     b hook_AromaItemCheck
 
+.section .patch_OverrideWalletSpiderHouse
+.global patch_OverrideWalletSpiderHouse
+patch_OverrideWalletSpiderHouse:
+@Override to use the progressive wallet instead.
+    mov r2,#0x49
+
 .section .patch_CheckMoTRequirement
 .global patch_CheckMoTRequirement
 patch_CheckMoTRequirement:
@@ -319,6 +330,12 @@ patch_CouplesMaskGiveItem:
 .global patch_RemoveCouplesMaskMessage
 patch_RemoveCouplesMaskMessage:
     b hook_AdjustCouplesMaskMessage
+
+.section .patch_OverrideBankerWalletReward
+.global patch_OverrideBankerWalletReward
+patch_OverrideBankerWalletReward:
+@Override to use the progressive wallet instead.
+    mov r2,#0x48
 
 .section .patch_loader
 .global loader_patch


### PR DESCRIPTION
Fix archery item overrides.

Fix banker override and spiderhouse override.

These now use our custom progressive items so all should be well.